### PR TITLE
Update hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ If you would like to directly contribute to Aspine, you can fork this repository
   * On Windows or macOS, download node.js and redis from their websites, and install them.
   * On GNU+Linux, you should be able to find these in your package manager (e.g. `apt`/`dpkg`, `yum`/`dnf`, `zypper`, `pacman`). npm may be in a separate package from node.js.
 * Open a terminal or command prompt, navigate to the directory in which you cloned the Aspine git repository, and run `redis-server redis.conf`.
-* Open another terminal or command prompt, navigate to that same directory, and run `node ./serve.js insecure`, or `node ./serve.js insecure fake` to use the `sample.json` file instead of pulling from Aspen (for faster testing).
+* Open another terminal or command prompt, navigate to that same directory, and run `npm install` to install the required dependencies.
+* In the same terminal or command prompt, run `node ./serve.js insecure`, or `node ./serve.js insecure fake` to use the `sample.json` file instead of pulling from Aspen (for faster testing).
 
 These instructions have only been tested on GNU+Linux. You might need to change your `PATH` on Windows if you get an error saying that `node` is not found after installing node.js.
 


### PR DESCRIPTION
I forgot to mention that people should run `npm install`. I have now added it.