### PR TITLE
Update package.json to reflect license

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/maxtkc/aspine.git"
   },
   "author": "Max Katz-Christy, Cole Killian",
-  "license": "UNLICENSED",
+  "license": "GPL-3.0-only",
   "bugs": {
     "url": "https://github.com/maxtkc/aspine/issues"
   },


### PR DESCRIPTION
Because the license of Aspine is GPL 3.0, I updated package.json to have this information. If you would like to have Aspine be compatible with future versions of the GPL, you can change "GPL-3.0-only" to "GPL-3.0-or-later".