### PR TITLE
Fix main Aspine header being too bold on Firefox + Firefox-derived browsers

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -19,6 +19,7 @@ h4#title {
 	position: absolute;
 	font-family: Poppins-Bold, Arial, Helvetica, sans-serif;
 	font-size: 80px;
+	font-weight: normal;
 	color: #00551D;
 	left: 0px;
 	right: 0px;


### PR DESCRIPTION
Firefox and browsers derived from it apply `font-weight: bold;` to the main "Aspine" header because it is a `h4` element, but because the font family (`Poppins-Bold`) is already bold, this causes these browsers to render the heading as being very bold.

Screenshots:
<details><summary>Chromium 79</summary>

![Screenshot at 2020-01-09 17-47-54](https://user-images.githubusercontent.com/45520974/72111571-2bc0cf80-3309-11ea-8866-47d25a5dc1ae.png)
</details>



<details><summary>Firefox 72, before change</summary>

![Screenshot at 2020-01-09 17-47-48](https://user-images.githubusercontent.com/45520974/72111578-31b6b080-3309-11ea-8531-7afb206c4e06.png)
</details>

<details>
<summary>Firefox 72, after change</summary>

![Screenshot at 2020-01-09 17-52-29](https://user-images.githubusercontent.com/45520974/72111580-34b1a100-3309-11ea-8711-97d733e4a3f8.png)
</details>
