### PR TITLE
Add version number and add message for no-JS visitors

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,51 @@
+# Maintenance
+
+This file is meant for noting information relating to project maintenance
+so that maintainers have a written record of key procedures.
+
+## Tagging a release
+
+GitHub provides a "Releases" mechanism that offers to tag releases
+automatically, but this creates lightweight tags and not annotated tags,
+which means that `git describe` will ignore any tags created from GitHub's
+website.
+
+To tag a release, first run `git tag -s v$MAJOR.$MINOR.$PATCH $REF`,
+replacing `$MAJOR.$MINOR.$PATCH` with the version number
+(following [semantic versioning][1]) and replacing `$REF` with the ref
+(usually a commit or branch) which should be tagged
+(this defaults to the current `HEAD`).
+Replace `-s` with `-a` if you do not have an OpenPGP key set up with Git
+and linked to your GitHub account.
+
+For the tag message, add the changelog entry for the release with any other
+pertinent information before the changelog entry. As with commit messages,
+remember to wrap lines at 72 characters. Do not use Markdown syntax in the tag
+message&mdash;symbols from code or filenames can be used without backticks and
+pull request or issue numbers can be kept as `#xxx` without a URL.
+
+Do not include any information in the tag description that you expect to change
+in the near future (e.g. "this version has not yet been put on the production
+server"). Such information can be included in the "Release" on GitHub.
+
+To publish the tag, run `git push --tags`.
+
+After tagging a release, click on "Draft a new release" under "Releases"
+and select the newly created tag. Use the version number (without `v`)
+as the release title and the tag description (with any mutable information
+as necessary) as the release description. Markdown syntax may be used here.
+
+## Modifying a tag message
+
+If, for some reason, you need to modify a tag message, run
+`git tag -sf $TAG $TAG^{}` (replacing `$TAG` with the name of the tag)
+and update the message. To publish the tag, run `git push -f --tags`.
+
+## Moving a tag
+
+If some extraordinary circumstance necessitates that a tag be moved to another
+commit, this can be done using `git tag -f $TAG $REF` where `$TAG` is the name
+of the tag and `$REF` is the ref to which the tag should now point.
+The newly moved tag can be published with `git push -f --tags`.
+
+[1]: https://semver.org/spec/v2.0.0.html

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -27,6 +27,11 @@ body, html {
   font-family: Poppins-Regular, sans-serif;
 }
 
+noscript p {
+  margin: 0 auto;
+  max-width: 960px;
+}
+
 /*---------------------------------------------*/
 a {
   font-family: Poppins-Regular;

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -35,6 +35,11 @@ body, html {
   text-align: center;
 }
 
+noscript p {
+  margin: 0 auto;
+  max-width: 960px;
+}
+
 /*---------------------------------------------*/
 a {
   font-family: Poppins-Regular;

--- a/public/home.html
+++ b/public/home.html
@@ -34,6 +34,18 @@
   <script src="vendor/pdf.js/pdf.min.js"></script>
 </head>
 <body>
+  <noscript>
+    <p><strong>
+      Aspine is designed to work mainly as a client-side web application
+      to maintain security and privacy, which means that most of the code is
+      JavaScript code run in your Web browser.
+      Aspine is free/libre and open source software with source code available
+      at
+      <a href="https://github.com/Aspine/aspine/">https://github.com/Aspine/aspine/</a>.
+      Please enable JavaScript in your Web browser in order to use Aspine.
+    </strong></p>
+  </noscript>
+
   <div id="header" onclick="openTab(event, 'clock')">
     <div class="logo">
       <canvas id="small_clock" width="400" height="400"></canvas>

--- a/public/home.html
+++ b/public/home.html
@@ -215,6 +215,7 @@
       <canvas id="pdf-canvas" width="400" height="400"></canvas>
     </div>
   </div>
+  <p>Aspine version: <span id="version">(loading&hellip;)</span></p>
   <script type="text/javascript" src="js/clock.js"></script>
   <!--<script type="text/javascript" src="/vendor/jscolor/jscolor.js"></script>-->
   <script type="text/javascript" src="js/calculate_grade.js"></script>

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -951,3 +951,8 @@ function openTab(evt, tab_name) {
 }
 
 document.getElementById("default_open").click();
+
+// Populate the version number at the bottom of the page.
+// Pointfree style does not work here because jQuery's .text behaves both as
+// an attribute and as a function.
+$.ajax("/version").then(ver => $("#version").text(ver));

--- a/public/login.html
+++ b/public/login.html
@@ -27,6 +27,18 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <noscript>
+    <p><strong>
+      Aspine is designed to work mainly as a client-side web application
+      to maintain security and privacy, which means that most of the code is
+      JavaScript code run in your Web browser.
+      Aspine is free/libre and open source software with source code available
+      at
+      <a href="https://github.com/Aspine/aspine/">https://github.com/Aspine/aspine/</a>.
+      Please enable JavaScript in your Web browser in order to use Aspine.
+    </strong></p>
+  </noscript>
+  
   <header></header>	
   <nav></nav>
   <main>

--- a/serve.js
+++ b/serve.js
@@ -15,7 +15,7 @@ const fs = require('fs');
 const https = require('https');
 const args = require('minimist')(process.argv.slice(2));
 const compression = require('compression');
-const pjson = require('./package.json');
+const child_process = require('child_process');
 // -------------------------------------------
 
 if (args.hasOwnProperty('help') || args._.includes('help')) {
@@ -131,8 +131,10 @@ app.use('/fonts/fontawesome/webfonts', express.static(
 ));
 
 // Endpoint to expose version number to client
-app.get('/version', (req, res) => {
-    res.send(pjson.version);
+app.get('/version', async (req, res) => {
+    child_process.exec('git describe',
+      (error, stdout, stderr) => res.send(stdout)
+    );
 });
 
 app.use(function(req, res, next) { // enable cors

--- a/serve.js
+++ b/serve.js
@@ -15,6 +15,7 @@ const fs = require('fs');
 const https = require('https');
 const args = require('minimist')(process.argv.slice(2));
 const compression = require('compression');
+const pjson = require('./package.json');
 // -------------------------------------------
 
 if (args.hasOwnProperty('help') || args._.includes('help')) {
@@ -128,6 +129,11 @@ new Map([
 app.use('/fonts/fontawesome/webfonts', express.static(
     __dirname + '/node_modules/@fortawesome/fontawesome-free/webfonts/'
 ));
+
+// Endpoint to expose version number to client
+app.get('/version', (req, res) => {
+    res.send(pjson.version);
+});
 
 app.use(function(req, res, next) { // enable cors
   res.header("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Add an endpoint `/version` that gets the current version of Aspine from `git describe`, display this version on the home page, and add a `<noscript>` tag with a message telling visitors with JavaScript disabled that Aspine requires JavaScript to be enabled.

Using `git describe` to get the version number instead of just reading from `package.json` has the advantage that changes made after a version is tagged are incorporated into the version number. For example: when on version 2.2.1, `git describe` outputs `v2.2.1`, but when on the branch `version` from which this PR was initiated, `git describe` outputs `v2.2.1-4-gc9803ee` because the branch is 4 commits ahead of `v2.2.1` and the latest commit is `gc9803ee`.