### PR TITLE
Change build-lite.sh to POSIX sh syntax

### DIFF
--- a/public/js/buttonFunctions.js
+++ b/public/js/buttonFunctions.js
@@ -294,7 +294,7 @@ let exportTableData = async function(prefs) {
 //#ifdef lite
 /*
   obj.version = (
-//#include $version
+//#include version
   );
 */
 //#endif
@@ -375,7 +375,7 @@ let importTableData = async function(obj) {
 //#ifdef lite
 /*
   let version = (
-//#include $version
+//#include version
   );
 */
 //#endif

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1059,7 +1059,7 @@ $.ajax("/version").then(ver => $("#version").text(ver));
 //#ifdef lite
 /*
 $("#version").text(
-//#include $version
+//#include version
 );
 */
 //#endif


### PR DESCRIPTION
This should solve incompatibilities with non-GNU systems.

@kdk1616, would you check if this works on macOS?

Windows (without Cygwin/MSYS/WSL) is not supported.