### PR TITLE
Use leaner Plotly.js bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -550,10 +550,10 @@
         "worker-loader": "^2.0.0"
       }
     },
-    "plotly.js-dist": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.53.0.tgz",
-      "integrity": "sha512-9TTjqMV9Nbq1zKOmcffRBRbGTniu/UuQGLH1EVoE5ooPzxTZDhrpFFkU8mRsCaLiwZLGEjwXgXFWjyLegkSKAQ=="
+    "plotly.js-cartesian-dist-min": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-cartesian-dist-min/-/plotly.js-cartesian-dist-min-1.54.1.tgz",
+      "integrity": "sha512-+qGP1Nw6cb7dKqHqWIfeF1YebpKfrJhuhkGx6L2eGElvbTZ52Upf8weraFB5WBZLvF4kh+yCNoaO9NvfUI1bpw=="
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "minimist": "^1.2.5",
     "node-fetch": "^2.3.0",
     "pdfjs-dist": "^2.3.200",
-    "plotly.js-dist": "^1.53.0",
+    "plotly.js-cartesian-dist-min": "^1.53.0",
     "tabulator-tables": "~4.1.5",
     "tilt.js": "^1.2.1"
   }

--- a/serve.js
+++ b/serve.js
@@ -100,7 +100,7 @@ new Map([
     ],
     [
         '/vendor/plotly.js/plotly.js',
-        '/node_modules/plotly.js-dist/plotly.js'
+        '/node_modules/plotly.js-cartesian-dist-min/plotly-cartesian.min.js'
     ],
     [
         '/vendor/tabulator/tabulator.min.js',


### PR DESCRIPTION
The JavaScript bundle in the `plotly.js-dist` package is 7.2 MB (1.7 MB gzipped). Using the `plotly.js-cartesian-dist-min` package reduces this to 1.0 MB (343 kB gzipped), which is still pretty heavy but is an improvement. Issue #122 tracks further developments (eventually replacing Plotly.js with a more lightweight library such as D3).