### PR TITLE
Add download button to Reports tab

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -319,6 +319,10 @@
       <span id="expand-pdf-icon" class="right hover pointer" onclick="toggle_fullscreen_pdf()">
         <i class="fa fa-expand-alt" aria-hidden="true"></i>
       </span>
+
+      <span class="right hover pointer" onclick="download_pdf()" aria-label="Download PDF">
+        <i class="fa fa-download" aria-hidden="true"></i>
+      </span>
       
       <span class="right" style="font-size:26px;position:relative;padding: 0px 15px;top:3px; cursor:default;">
         |

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -572,6 +572,15 @@ let next_page_pdf = function() {
   }
 }
 
+async function download_pdf() {
+  // Get current PDF file's raw data
+  const data = await pdf.getData();
+  // Use application/octet-stream MIME type to force a download (instead of
+  // having it open in a browser PDF viewer)
+  saveAs(new Blob([data], {
+    type: "application/octet-stream"
+  }), `${currentTableData.pdf_files[currentPdfIndex].title}.pdf`);
+}
 
 function pdf_closeAllSelect(elmnt) {
   /* A function that will close all select boxes in the document,


### PR DESCRIPTION
Closes #143. This makes it more possible for users to download a PDF file directly from the Aspine Reports tab without needing to go to Aspen.