### PR TITLE
requestAnimationFrame update for clock

### DIFF
--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -24,9 +24,14 @@ let current_schedule = covid_schedule ? "covid" : "regular";
 // current date and time.
 let date_override = undefined;
 
-let last_thousand = 0
+let last_interval = 0
+const refreshes_per_second = 4
 function redraw_clock_with_timestamp(timestamp) {
-    redraw_clock();
+    if (timestamp > last_interval*1000/refreshes_per_second) {
+        last_interval++;
+        console.log(last_interval)
+        redraw_clock();
+    }
     window.requestAnimationFrame(redraw_clock_with_timestamp);
 }
 

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -24,12 +24,21 @@ let current_schedule = covid_schedule ? "covid" : "regular";
 // current date and time.
 let date_override = undefined;
 
+let last_thousand = 0
+function redraw_clock_with_timestamp(timestamp) {
+    redraw_clock();
+    window.requestAnimationFrame(redraw_clock_with_timestamp);
+}
+
 let schedulesCallback = function(response) {
     schedules = response;
     redraw_clock();
-    setInterval(function() {
-        redraw_clock();
-    }, 1000);
+
+    window.requestAnimationFrame(redraw_clock_with_timestamp);
+
+    // setInterval(function() {
+    //     redraw_clock();
+    // }, 1000);
 };
 
 //#ifndef lite

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -24,26 +24,21 @@ let current_schedule = covid_schedule ? "covid" : "regular";
 // current date and time.
 let date_override = undefined;
 
-let last_interval = 0
-const refreshes_per_second = 4
-function redraw_clock_with_timestamp(timestamp) {
-    if (timestamp > last_interval*1000/refreshes_per_second) {
-        last_interval++;
-        redraw_clock();
-    }
-    window.requestAnimationFrame(redraw_clock_with_timestamp);
-}
-
-let schedulesCallback = function(response) {
+function schedulesCallback(response) {
     schedules = response;
-    redraw_clock();
 
-    window.requestAnimationFrame(redraw_clock_with_timestamp);
+    let last_interval = 0;
+    const redraw_clock_with_timestamp = timestamp => {
+        // Redraw clock 4 times per second (once every 1000/4 milliseconds)
+        if (timestamp > last_interval * 1000/4) {
+            last_interval++;
+            redraw_clock();
+        }
+        window.requestAnimationFrame(redraw_clock_with_timestamp);
+    }
 
-    // setInterval(function() {
-    //     redraw_clock();
-    // }, 1000);
-};
+    redraw_clock_with_timestamp();
+}
 
 //#ifndef lite
 $.ajax({

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -29,7 +29,6 @@ const refreshes_per_second = 4
 function redraw_clock_with_timestamp(timestamp) {
     if (timestamp > last_interval*1000/refreshes_per_second) {
         last_interval++;
-        console.log(last_interval)
         redraw_clock();
     }
     window.requestAnimationFrame(redraw_clock_with_timestamp);


### PR DESCRIPTION
closes #135 
switches setInterval to requestAnimationFrame, change the constant to change the frames/second or remove the constant altogether if you feel like hardcoding it. Also if you feel like it's best you could fix redraw_clock so it works with requestAnimationFrame but you could also just keep it as separate functions which is what I suggest.