### PR TITLE
switch to 'aspine listening on port' instead of 'example app'

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -34,7 +34,7 @@ const port = 8080;
 
 const app = express();
 app.use(compression({ filter: (..._) => true }));
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+app.listen(port, () => console.log(`Aspine listening on port ${port}!`));
 
 // // redis setup
 // client.on("error", function (err) {


### PR DESCRIPTION
Changed serve.js file to print 'Aspine listening on port' instead of 'Example app.' 