### PR TITLE
Improve formatting and text on login page

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -207,14 +207,14 @@ iframe {
 /*------------------------------------------------------------------
 [  ]*/
 #login100-form {
-  width: 290px;
+  width: 320px;
   margin: auto 0 auto 0;
   height: fit-content;
 }
 
 #login100-form-title {
   font-family: Poppins-Bold;
-  font-size: 24px;
+  font-size: 35px;
   color: #333333;
   line-height: 1.2;
   text-align: center;
@@ -231,6 +231,7 @@ iframe {
   width: 100%;
   z-index: 1;
   margin-bottom: 10px;
+  margin-top: 5px;
 }
 
 .input100 {
@@ -325,6 +326,7 @@ iframe {
   flex-wrap: wrap;
   justify-content: center;
   padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 #login100-form-btn {

--- a/public/home.html
+++ b/public/home.html
@@ -157,7 +157,7 @@
       <span class="close" onclick="hideModal('corrections')">&times;</span>
       <h3>Test Corrections</h3>
       <p style='margin-bottom: 20px;'>
-        Enter Test Corrections % possible for this assignment:
+        Enter possible % for this assignment after test corrections:
       </p>
       <input type="text" id="corrections_modal_input">
       <input type="button" value="Apply Corrections" onclick="correct()">

--- a/public/login.html
+++ b/public/login.html
@@ -58,7 +58,7 @@
             </span>
             <div class="text-center p-t-12">
               <span class="txt1" style="color:#595959">
-                Use Aspen credentials or leave blank to import data
+                Aspen credentials or blank to import data
               </span>
             </div>
             <!-- Username Input -->
@@ -91,19 +91,19 @@
             </div>
             <div class="text-center p-t-12">
               <span class="txt1" style="color:#595959">
-                For issues and feature requests, please let us know with this
-                <a href="https://goo.gl/forms/PYQDtzkp0vHJbFLz2">google form</a>!
+                Issues or feature requests: 
+                <a href="https://goo.gl/forms/PYQDtzkp0vHJbFLz2">Google Form</a>
                 <br>
-                To see the code and contribute to this open source project
-                check out our <a href="https://github.com/maxtkc/aspine">github</a>!
+                Open source code: 
+                <a href="https://github.com/maxtkc/aspine">GitHub</a>
               </span>
             </div>
             <div class="text-center p-t-12">
               <span class="txt1" style="color:#595959">
-                Check out our <a href="https://www.cpsd.us/privacy">Privacy Policy</a>
+                Privacy policy: 
+                <a href="https://www.cpsd.us/privacy">CPSD</a>
               </span>
             </div>
-            <br>
             <div class="text-center">
               <img src="images/district-logo.png" style="width:75%">
             </div>


### PR DESCRIPTION
In my opinion, the login page looks a bit cluttered with too many lines of text and weird text padding, spacing, and margins. This pull request aims to clean up the login page by reducing the amount of text (everything is still there though), and tweaking some of the spacings. I have attached two comparison images below. I believe it looks better than before, but I understand that this is subjective so am open to feedback! I have also tested the new design on mobile using Safari developer tools and it looks good there too. (Side note: in a separate commit I also changed the message when you edit assignments since it was confusing.)

Old Format (below)
<img width="1439" alt="Screen Shot 2020-10-30 at 7 22 12 PM" src="https://user-images.githubusercontent.com/31443287/97764550-5c1a6a00-1ae5-11eb-8c84-d0c45b9fa2b7.png">

New Format (below)
<img width="1440" alt="Screen Shot 2020-10-30 at 7 23 01 PM" src="https://user-images.githubusercontent.com/31443287/97764556-5fadf100-1ae5-11eb-9ee0-ead80dfb2a16.png">



