### PR TITLE
makes clock fall in line with rest of divs

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -323,7 +323,7 @@ div.tabcontent, div.tab {
 
 .logo {
   height: 100px;
-  margin: 10px 10px 25px 10px;
+  margin: 10px 10px 25px 1%;
   width: 100px;
   float: left;
 }
@@ -590,7 +590,7 @@ p#small_clock_period {
   
   position: absolute;
   top: 110px;
-  left: 10px;
+  left: 1%;
 }
 p#large_clock_period {
   font-size: 50px;


### PR DESCRIPTION
div uses width: 98%, having a static 10px left margin won't correctly line the clock up with it and it bugs me. 1% left margin /1 % left absolute position lets it fall correctly inline with everything else. Super tiny change but it's a nice QoL one in my opinion