### PR TITLE
Hide assignments from recent activity and hide "Most Recent Activity" from home page (new)

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -300,7 +300,7 @@
     <div id='calendar'></div>
   </div>
   -->
-  <div id="recent" class="tabcontent" onload="load_recent()">
+  <div id="recent" class="tabcontent">
     <h3>Recent Attendance</h3>
     <!-- <label class="switch">
       <input type="checkbox" id="recent_toggle" onclick="recent_toggle();">

--- a/public/home.html
+++ b/public/home.html
@@ -246,8 +246,9 @@
   <div id="grades" class="tabcontent">
     <div id="classesTable"></div>
     <div id="mostRecentDiv" style="display:none">
-      <h3 align="left">Most Recent Activity:</h3>
-      <div id="mostRecentTable"></div>
+      <!-- hide most recent activity; removed from aspen -->
+      <!-- <h3 align="left">Most Recent Activity:</h3> -->
+      <div id="mostRecentTable" style="display: none;"></div>
     </div>
     <div id="categoriesTable"></div>
     <div id="assignmentsTable"></div>

--- a/public/home.html
+++ b/public/home.html
@@ -66,7 +66,7 @@
 
   <div class="tab">
     <button class="tablinks" onclick="openTab(event, 'grades')" id="default_open">Grades</button>
-    <button class="tablinks" onclick="openTab(event, 'recent')">Recent Activity</button>
+    <button class="tablinks" onclick="openTab(event, 'recent'), load_recent()">Recent Activity</button>
     <button class="tablinks" onclick="openTab(event, 'schedule')">Schedule</button>
     <button class="tablinks" onclick="openTab(event, 'clock')">Clock</button>
     <!--<button class="tablinks" onclick="openTab(event, 'calendar-tab')">Calendar</button>-->
@@ -300,13 +300,14 @@
     <div id='calendar'></div>
   </div>
   -->
-  <div id="recent" class="tabcontent">
-    <label class="switch">
+  <div id="recent" class="tabcontent" onload="load_recent()">
+    <h3>Recent Attendance</h3>
+    <!-- <label class="switch">
       <input type="checkbox" id="recent_toggle" onclick="recent_toggle();">
       <span class="slider round"></span>
       <p id="recent_title" class="unselectable">Assignments</p>
-    </label>
-    <div id="recentActivity"></div>
+    </label>-->
+    <div id="recentActivity"></div> 
     <div id="recentAttendance"></div>
   </div>
   <div id="reports" class="tabcontent">

--- a/public/home.html
+++ b/public/home.html
@@ -67,7 +67,7 @@
   <div class="tab">
     <button class="tablinks" onclick="openTab(event, 'grades')" id="default_open">Grades</button>
     <button class="tablinks" onclick="openTab(event, 'schedule')">Schedule</button>
-    <button class="tablinks" onclick="openTab(event, 'recent'), load_recent()">Attendance</button>
+    <button class="tablinks" onclick="openTab(event, 'recent')">Attendance</button>
     <!--<button class="tablinks" onclick="openTab(event, 'clock')">Clock</button>-->
     <!-- TODO: post-covid, setting lunch should be migrated to settings -->
     <!--<button class="tablinks" onclick="openTab(event, 'calendar-tab')">Calendar</button>-->
@@ -308,8 +308,9 @@
       <span class="slider round"></span>
       <p id="recent_title" class="unselectable">Assignments</p>
     </label>-->
-    <div id="recentActivity"></div> 
-    <div id="recentAttendance"></div>
+    <div id="recentActivity" style="display: none"></div>
+    <div id="recentAttendance" style="display: block"></div>
+    <!-- recentActivity is hidden because Aspen does not display recent assignments -->
   </div>
   <div id="reports" class="tabcontent">
     <div class="pdf_topnav">

--- a/public/home.html
+++ b/public/home.html
@@ -66,9 +66,10 @@
 
   <div class="tab">
     <button class="tablinks" onclick="openTab(event, 'grades')" id="default_open">Grades</button>
-    <button class="tablinks" onclick="openTab(event, 'recent'), load_recent()">Recent Activity</button>
     <button class="tablinks" onclick="openTab(event, 'schedule')">Schedule</button>
-    <button class="tablinks" onclick="openTab(event, 'clock')">Clock</button>
+    <button class="tablinks" onclick="openTab(event, 'recent'), load_recent()">Attendance</button>
+    <!--<button class="tablinks" onclick="openTab(event, 'clock')">Clock</button>-->
+    <!-- TODO: post-covid, setting lunch should be migrated to settings -->
     <!--<button class="tablinks" onclick="openTab(event, 'calendar-tab')">Calendar</button>-->
     <button class="tablinks" onclick="openTab(event, 'reports')" id="reports_open">Reports</button>
 <!--#ifndef lite-->
@@ -302,7 +303,6 @@
   </div>
   -->
   <div id="recent" class="tabcontent">
-    <h3>Recent Attendance</h3>
     <!-- <label class="switch">
       <input type="checkbox" id="recent_toggle" onclick="recent_toggle();">
       <span class="slider round"></span>

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -831,6 +831,10 @@ function responseCallback(response, includedTerms) {
         if (currentTableData.recent.recentAttendanceArray[i].tardy === "true") {
             currentTableData.recent.recentAttendanceArray[i].event += "Tardy ";
         }
+        // addition for COVID
+        if (currentTableData.recent.recentAttendanceArray[i].code === "VP") {
+            currentTableData.recent.recentAttendanceArray[i].event += "VP ";
+        }
     }
 
     let activityArray = currentTableData.recent.recentActivityArray.slice();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1010,21 +1010,29 @@ function pdfCallback(response) {
         generate_pdf(pdf_index);
     }
 }
+// Currently no need for toggle; there are no recent assignments
+// function recent_toggle() {
+//     if (!document.getElementById("recent_toggle").checked) {
+//         recentActivity.setData(tableData.recent.recentActivityArray);
+//         document.getElementById("recentActivity").style.display = "block";
+//         document.getElementById("recentAttendance").style.display = "none";
+//         document.getElementById("recent_title").innerHTML = "Assignments";
+//         recentActivity.redraw();
+//     } 
+//     else {
+//         //recentActivity.setData(tableData.recent.recentAttendanceArray);
+//         document.getElementById("recentActivity").style.display = "none";
+//         document.getElementById("recentAttendance").style.display = "block";
+//         document.getElementById("recent_title").innerHTML = "Attendance";
+//         recentAttendance.redraw();
+//     }
+// }
 
-function recent_toggle() {
-    if (!document.getElementById("recent_toggle").checked) {
-        //recentActivity.setData(tableData.recent.recentActivityArray);
-        document.getElementById("recentActivity").style.display = "block";
-        document.getElementById("recentAttendance").style.display = "none";
-        document.getElementById("recent_title").innerHTML = "Assignments";
-        recentActivity.redraw();
-    } else {
-        //recentActivity.setData(tableData.recent.recentAttendanceArray);
-        document.getElementById("recentActivity").style.display = "none";
-        document.getElementById("recentAttendance").style.display = "block";
-        document.getElementById("recent_title").innerHTML = "Attendance";
-        recentAttendance.redraw();
-    }
+// Load the recent attendance without assignments; assignments disabled in Aspen
+function load_recent() {
+    document.getElementById("recentActivity").style.display = "none";
+    document.getElementById("recentAttendance").style.display = "block";
+    recentAttendance.redraw();
 }
 
 function schedule_toggle() {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1015,29 +1015,24 @@ function pdfCallback(response) {
     }
 }
 // Currently no need for toggle; there are no recent assignments
-// function recent_toggle() {
-//     if (!document.getElementById("recent_toggle").checked) {
-//         recentActivity.setData(tableData.recent.recentActivityArray);
-//         document.getElementById("recentActivity").style.display = "block";
-//         document.getElementById("recentAttendance").style.display = "none";
-//         document.getElementById("recent_title").innerHTML = "Assignments";
-//         recentActivity.redraw();
-//     } 
-//     else {
-//         //recentActivity.setData(tableData.recent.recentAttendanceArray);
-//         document.getElementById("recentActivity").style.display = "none";
-//         document.getElementById("recentAttendance").style.display = "block";
-//         document.getElementById("recent_title").innerHTML = "Attendance";
-//         recentAttendance.redraw();
-//     }
-// }
-
-// Load the recent attendance without assignments; assignments disabled in Aspen
-function load_recent() {
-    document.getElementById("recentActivity").style.display = "none";
-    document.getElementById("recentAttendance").style.display = "block";
-    recentAttendance.redraw();
+/*
+function recent_toggle() {
+    if (!document.getElementById("recent_toggle").checked) {
+        recentActivity.setData(tableData.recent.recentActivityArray);
+        document.getElementById("recentActivity").style.display = "block";
+        document.getElementById("recentAttendance").style.display = "none";
+        document.getElementById("recent_title").innerHTML = "Assignments";
+        recentActivity.redraw();
+    }
+    else {
+        //recentActivity.setData(tableData.recent.recentAttendanceArray);
+        document.getElementById("recentActivity").style.display = "none";
+        document.getElementById("recentAttendance").style.display = "block";
+        document.getElementById("recent_title").innerHTML = "Attendance";
+        recentAttendance.redraw();
+    }
 }
+*/
 
 function schedule_toggle() {
     if (document.getElementById("schedule_toggle").checked) {


### PR DESCRIPTION
Description of original pull request (#161):
> Aspen doesn't show recent assignments anymore, so I hid the toggle from that page, and it now just shows recent attendance. I also hid the most recent activity on the grades tab, either permanently or at least until we have our own algorithm for calculating recent assignments. I also fixed the issue of the "VP" attendance event not showing correctly.
closes #144
closes #159

I had to create a new pull request because I pushed the wrong branch and accidentally irreversibly closed the other pull request.