### PR TITLE
Changed Aspine header onclick behavior to open grades instead of clock

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -55,7 +55,7 @@
     </strong></p>
   </noscript>
 
-  <div id="header" onclick="openTab(event, 'clock')">
+  <div id="header" onclick="openTab(event, 'grades')">
     <div class="logo">
       <canvas id="small_clock" width="400" height="400"></canvas>
       <img id="logo" src="images/logo-circle198x198.png" alt="logo" hidden>


### PR DESCRIPTION
Fix for issue #168 ("Clicking on 'Aspine' goes to clock instead of home page").