### PR TITLE
Fix confusing message when editing assignments

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -158,7 +158,7 @@
       <span class="close" onclick="hideModal('corrections')">&times;</span>
       <h3>Test Corrections</h3>
       <p style='margin-bottom: 20px;'>
-        Enter Test Corrections % possible for this assignment:
+        Enter the percentage of lost points which are redeemable:
       </p>
       <input type="text" id="corrections_modal_input">
       <input type="button" value="Apply Corrections" onclick="correct()">


### PR DESCRIPTION
Discussed this two meetings ago. Concluded that saying "enter the percentage of lost points which are redeemable" is most clear.