### PR TITLE
Add an info tab

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -135,12 +135,12 @@ h4#title {
   font-family: Poppins-Bold, Arial, Helvetica, sans-serif;
   font-weight: bold;
   font-size: 1.25em;
-  color: #00551D;
+  color: var(--green2);
 }
 
 .info-text {
   font-size: 1em;
-  color: #000000;
+  color: var(--black);
   margin-bottom: 1.5em;
 }
 

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -131,6 +131,13 @@ h4#title {
   cursor: pointer;
 }
 
+.info-header {
+  font-family: Poppins-Bold, Arial, Helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 18px;
+  color: #00551D
+}
+
 .tabulator-col {
   height: 35px;
 }

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -134,8 +134,14 @@ h4#title {
 .info-header {
   font-family: Poppins-Bold, Arial, Helvetica, sans-serif;
   font-weight: bold;
-  font-size: 18px;
-  color: #00551D
+  font-size: 1.25em;
+  color: #00551D;
+}
+
+.info-text {
+  font-size: 1em;
+  color: #000000;
+  margin-bottom: 1.5em;
 }
 
 .tabulator-col {

--- a/public/home.html
+++ b/public/home.html
@@ -363,68 +363,70 @@
   </div>
   <div id="information" class="tabcontent">
     <div id="instructions-header" style="text-align: left">
-      <h2 class="info-header">What is Aspine?</h2>
+      <h2 class="info-header">Overview</h2>
       <p class="info-text">
-      Aspine is a tool for CPSD students to make it easier to see and predict
-      grades. It allows you to predict what your grades would be if you scored
-      better on a test, or got an 100 on an upcoming project.
+      Aspine is a frontend for Aspen that makes it easier for CPSD students to
+      see and predict their grades. For example, you can predict what your
+      grade in a class, and your GPA, would be if you scored better on a test,
+      or got an A on an upcoming project.
       </p>
-      <h2 class="info-header">Editing Assignments</h2>
+      <h2 class="info-header">Editing assignments</h2>
       <p class="info-text">
       Editing assignments is easy. In the <strong>Grades</strong> tab, select a
-      class to see its categories and the individual assignment. If you select
-      a category, it will filter the assignments by that category. Everything
-      about an assignment is changeable. While this doesn't change the actual
-      grades entered in aspen, it will show a predicted grade based off of what
-      you entered. You can change assignment names, categories, scores and
-      maximum scores.
+      class to see its categories and the individual assignment. Selecting a
+      category filters the assignments by that category. Assignment names,
+      categories, scores, and maximum scores can all be modified and your
+      overall grade as well as category subtotals will be based on what you
+      entered.
       </p>
-      <h2 class="info-header">Adding Assignments</h2>
+      <h2 class="info-header">Adding assignments</h2>
       <p class="info-text">
-      When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter
-      in a basic assignment in the currently selected category, which you can
-      change however you like to reflect possible upcoming assignments.
+      Clicking the plus (<i class="fa fa-plus"></i>) icon enters a new
+      assignment in the currently selected category, which you can change to
+      your liking to reflect possible upcoming assignments.
       </p>
-      <h2 class="info-header">Test Corrections</h2>
+      <h2 class="info-header">Test corrections</h2>
       <p class="info-text">
-      When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can
-      enter the percentage of points you could get back on test corrections.
-      For example, if a teacher was allowing you to get 50% of your points
-      back, you could enter 50 and it will calculate your grade with the
-      points back.
+      Clicking the hammer (<i class="fa fa-hammer"></i>) icon on an assignment
+      allows you to predict your grade if you are able to redeem a certain
+      percentage of the points you lost on the assignment. For example, if you
+      get a score of 80/100 on a test and your teacher allows you to get 50% of
+      your points back, entering 50% would cause Aspine to recalculate your
+      grade with a score of 90/100 on the test.
       </p>
-      <h2 class="info-header">Assignment Information</h2>
+      <h2 class="info-header">Assignment statistics</h2>
       <p class="info-text">
-      When you click the info ( <i class="fa fa-info"></i> ) icon, if your
-      teacher allows it for your class, you can see statistics about how well
-      you and your classmates did on that particular assignment.
+      For classes whose teachers share assignment statistics, clicking the info
+      (<i class="fa fa-info"></i>) icon on an assignment contextualizes your
+      score with a profile of your classmates' scores.
       </p>
-      <h2 class="info-header">Report Cards</h2>
+      <h2 class="info-header">Report cards</h2>
       <p class="info-text">
-      In the <strong>Reports</strong> tab, you can see both current and past
-      report cards.
+      In the <strong>Reports</strong> tab, you can view and download your
+      report cards and progress reports.
       </p>
       <h2 class="info-header">Clock</h2>
       <p class="info-text">
-      The clock is a CRLS geared clock that tells you exactly how long until
-      the next school related thing happens, be it the start of the school day,
-      the end of a class, or if it's already after school, just the normal
-      time.
+      During a school day, the clock (in the top-left corner) shows you the
+      name of your current class and the amount of time remaining until the end
+      of the class, or shows the amount of time until the beginning of school
+      if viewed before school starts.
       </p>
-      <h2 class="info-header">Importing/Exporting Grades</h2>
+      <h2 class="info-header">Importing/exporting grades</h2>
       <p class="info-text">
-      When you click the download ( <i class="fa fa-file-download"></i> ) icon,
-      it lets you select what grades you want to export. These grades can be
-      imported later by clicking the <strong>Current Year</strong> dropdown
-      menu and selecting <strong>Import Data</strong>.
+      Clicking the download (<i class="fa fa-file-download"></i>) icon lets you
+      export your grades in a machine-readable format that you can store on
+      your computer. You can import these back into Aspen at a later date by
+      clicking the <strong>Current Year</strong> dropdown menu and selecting
+      <strong>Import Data</strong>.
       </p>
-      <h2 class="info-header">GPA Type and Current Quarter</h2>
-      When you click the <strong>GPA Type</strong> button, it switches between
-      a normal 0-100 grade, an unweighted 0-4.0 GPA and a weighted 0-5.0 GPA.
-      When you click the <strong>Current Quarter</strong> dropdown, you can see
-      grades and assignments from other quarters.
+      <h2 class="info-header">GPA type and switching quarters</h2>
       <p class="info-text">
-
+      You can click the <strong>GPA Type</strong> button to toggle between
+      percentage, unweighted (4.0 scale), and weighted (5.0 scale) GPA. The
+      <strong>Current Quarter</strong> dropdown shows your GPA for each quarter
+      and also allows you to switch to another quarter to see its grades and
+      assignments.
       </p>
     </div>
   </div>

--- a/public/home.html
+++ b/public/home.html
@@ -397,7 +397,7 @@
       <h2 class="info-header">Assignment Statistics</h2>
       <p class="info-text">
       For classes where the teachers report assignment statistics, clicking the 
-      bar graph (<img src="../images/Bar_Graph.svg" width=18></img>) icon on an 
+      statistics (<i class="fa fa-info"></i>) icon on an 
       assignment contextualizes your score with a profile of your classmates' scores.
       </p>
       <h2 class="info-header">Report Cards</h2>

--- a/public/home.html
+++ b/public/home.html
@@ -361,24 +361,54 @@
       <canvas id="pdf-canvas" width="400" height="400"></canvas>
     </div>
   </div>
-  <div id="information" , class="tabcontent">
-    <div id="instructions-header" style="text-align: left; ">
-      <!-- <h1 style="text-align: left;">Instructions</h1><br> -->
-      <p></p>
-      <p class="info-header">What is Aspine?</p>
-      Aspine is a frontend service for Aspen to make it easier for students to see and predict their grades. It allows you to predict grades if they scored better on a test, or got an 100 on an upcoming project.<br><br>
-      <p class="info-header">Editing Assignments</p>
-      Editing assignments is easy. In the <b>Grades</b> tab, select a class to see its categories and the individual assignemnt. If you select a category, it will filter the assignments by that category. Everything about an assignemnt is changeable. While this doesn't change the actual grades entered in aspen, it will show a predicted grade based off of what you entered. You can change assignemnt names, categories, scores and maximum scores.<br><br>
-      <p class="info-header">Adding Assignments</p>
-      When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter in a basic assignment in the first category, which you can change as you so please to reflect possible upcoming assignments.<br><br>
-      <p class="info-header">Test Corrections</p>
-      When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can enter the percentage of points you could get back on test corrections. For example, if a teacher was allowing you to get 50% of your points back, you could enter 50 and it will calculate your grade thusly.<br><br>
-      <p class="info-header">Assignment Information</p>
-      When you click the info ( <i class="fa fa-info"></i> ) icon, if your teacher allows it for your class, you can see statistics about how well you and your classmates did on that particular assignment.<br><br>
-      <p class="info-header">Report Cards</p>
-      In the <b>Reports</b> tab, you can see both current and past report cards.<br><br>
-      <p class="info-header">Clock</p>
-      The clock is a CRLS geared clock that tells you exactly how long until the next school related thing happens, be it the start of the school day, the end of a class, or if it's already after school, just the normal time.
+  <div id="information" class="tabcontent">
+    <div id="instructions-header" style="text-align: left">
+      <h2 class="info-header">What is Aspine?</h2>
+      <p class="info-text">
+      Aspine is a frontend service for Aspen to make it easier for students to
+      see and predict their grades. It allows you to predict grades if they
+      scored better on a test, or got an 100 on an upcoming project.
+      </p>
+      <h2 class="info-header">Editing Assignments</h2>
+      <p class="info-text">
+      Editing assignments is easy. In the <strong>Grades</strong> tab, select a
+      class to see its categories and the individual assignemnt. If you select
+      a category, it will filter the assignments by that category. Everything
+      about an assignemnt is changeable. While this doesn't change the actual
+      grades entered in aspen, it will show a predicted grade based off of what
+      you entered. You can change assignemnt names, categories, scores and
+      maximum scores.
+      </p>
+      <h2 class="info-header">Adding Assignments</h2>
+      <p class="info-text">
+      When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter
+      in a basic assignment in the first category, which you can change as you
+      so please to reflect possible upcoming assignments.
+      </p>
+      <h2 class="info-header">Test Corrections</h2>
+      <p class="info-text">
+      When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can
+      enter the percentage of points you could get back on test corrections.
+      For example, if a teacher was allowing you to get 50% of your points
+      back, you could enter 50 and it will calculate your grade thusly.
+      </p>
+      <h2 class="info-header">Assignment Information</h2>
+      <p class="info-text">
+      When you click the info ( <i class="fa fa-info"></i> ) icon, if your
+      teacher allows it for your class, you can see statistics about how well
+      you and your classmates did on that particular assignment.
+      </p>
+      <h2 class="info-header">Report Cards</h2>
+      <p class="info-text">
+      In the <strong>Reports</strong> tab, you can see both current and past
+      report cards.
+      </p>
+      <h2 class="info-header">Clock</h2>
+      <p class="info-text">
+      The clock is a CRLS geared clock that tells you exactly how long until
+      the next school related thing happens, be it the start of the school day,
+      the end of a class, or if it's already after school, just the normal
+      time.
       </p>
     </div>
   </div>

--- a/public/home.html
+++ b/public/home.html
@@ -365,68 +365,67 @@
     <div id="instructions-header" style="text-align: left">
       <h2 class="info-header">Overview</h2>
       <p class="info-text">
-      Aspine is a frontend for Aspen that makes it easier for CPSD students to
-      see and predict their grades. For example, you can predict what your
-      grade in a class, and your GPA, would be if you scored better on a test,
-      or got an A on an upcoming project.
+      Aspine is a website that makes it easier for CPSD students to access and 
+      predict their grades. For example, a student can use Aspine to see how a 
+      better score on a test or an A on an upcoming project would affect their 
+      grade in a particular class as well as their GPA.
       </p>
-      <h2 class="info-header">Editing assignments</h2>
+      <h2 class="info-header">Editing Assignments</h2>
       <p class="info-text">
-      Editing assignments is easy. In the <strong>Grades</strong> tab, select a
-      class to see its categories and the individual assignment. Selecting a
-      category filters the assignments by that category. Assignment names,
-      categories, scores, and maximum scores can all be modified and your
-      overall grade as well as category subtotals will be based on what you
-      entered.
+      To edit assignments, select a class from the <strong>Grades</strong> tab 
+      to see its grading categories and individual assignments. Selecting a 
+      particular category displays the assignments in that category. Assignment 
+      names, categories, scores, and maximum scores can all be modified, which 
+      temporarily updates the overall grade and category subtotals based on what 
+      was entered.
       </p>
-      <h2 class="info-header">Adding assignments</h2>
+      <h2 class="info-header">Adding Assignments</h2>
       <p class="info-text">
-      Clicking the plus (<i class="fa fa-plus"></i>) icon enters a new
-      assignment in the currently selected category, which you can change to
-      your liking to reflect possible upcoming assignments.
+      Clicking the plus (<i class="fa fa-plus"></i>) icon adds a new assignment 
+      in the currently selected category, which can be edited to reflect possible 
+      upcoming assignments.
       </p>
-      <h2 class="info-header">Test corrections</h2>
+      <h2 class="info-header">Test Corrections</h2>
       <p class="info-text">
       Clicking the hammer (<i class="fa fa-hammer"></i>) icon on an assignment
-      allows you to predict your grade if you are able to redeem a certain
-      percentage of the points you lost on the assignment. For example, if you
-      get a score of 80/100 on a test and your teacher allows you to get 50% of
-      your points back, entering 50% would cause Aspine to recalculate your
-      grade with a score of 90/100 on the test.
+      allows you to predict your grade if it is possible to redeem a certain 
+      percentage of the points lost on that assignment. For example, if a student 
+      scores 80/100 on a test and their teacher allows them to get 50% of their 
+      points back, entering 50% would recalculate their grade with a score of 
+      90/100 on the test.
       </p>
-      <h2 class="info-header">Assignment statistics</h2>
+      <h2 class="info-header">Assignment Statistics</h2>
       <p class="info-text">
-      For classes whose teachers share assignment statistics, clicking the info
-      (<i class="fa fa-info"></i>) icon on an assignment contextualizes your
-      score with a profile of your classmates' scores.
+      For classes where the teachers report assignment statistics, clicking the 
+      bar graph (<img src="../images/Bar_Graph.svg" width=18></img>) icon on an 
+      assignment contextualizes your score with a profile of your classmates' scores.
       </p>
-      <h2 class="info-header">Report cards</h2>
+      <h2 class="info-header">Report Cards</h2>
       <p class="info-text">
-      In the <strong>Reports</strong> tab, you can view and download your
-      report cards and progress reports.
+      Use the <strong>Reports</strong> tab to view and download your report 
+      cards and progress reports.
       </p>
       <h2 class="info-header">Clock</h2>
       <p class="info-text">
-      During a school day, the clock (in the top-left corner) shows you the
-      name of your current class and the amount of time remaining until the end
-      of the class, or shows the amount of time until the beginning of school
-      if viewed before school starts.
+      During the school day, the clock found in the upper left-hand corner displays 
+      the name of your current class and the amount of time remaining in that class. 
+      If viewed before the start of the school day, the clock shows the amount of 
+      time left until first period starts.
       </p>
-      <h2 class="info-header">Importing/exporting grades</h2>
+      <h2 class="info-header">Importing/Exporting grades</h2>
       <p class="info-text">
-      Clicking the download (<i class="fa fa-file-download"></i>) icon lets you
-      export your grades in a machine-readable format that you can store on
-      your computer. You can import these back into Aspen at a later date by
-      clicking the <strong>Current Year</strong> dropdown menu and selecting
-      <strong>Import Data</strong>.
+      Clicking the download (<i class="fa fa-file-download"></i>) icon exports 
+      your grades in a machine-readable format stored on your computer. You can 
+      import these files back into Aspine later on by clicking the <strong>Current 
+      Year</strong> dropdown menu and selecting <strong>Import Data</strong>.
       </p>
-      <h2 class="info-header">GPA type and switching quarters</h2>
+      <h2 class="info-header">GPA Type and Switching Quarters</h2>
       <p class="info-text">
-      You can click the <strong>GPA Type</strong> button to toggle between
-      percentage, unweighted (4.0 scale), and weighted (5.0 scale) GPA. The
-      <strong>Current Quarter</strong> dropdown shows your GPA for each quarter
-      and also allows you to switch to another quarter to see its grades and
-      assignments.
+      Clicking on the <strong>GPA Type</strong> button toggles between displaying
+      your GPA on the 100 point scale, unweighted (4.0) scale, and weighted 
+      (5.0) scale. The <strong>Current Quarter</strong> dropdown displays your 
+      GPA for each quarter, which when clicked allows you to see your grades and 
+      assignments for that quarter.
       </p>
     </div>
   </div>

--- a/public/home.html
+++ b/public/home.html
@@ -365,9 +365,9 @@
     <div id="instructions-header" style="text-align: left">
       <h2 class="info-header">What is Aspine?</h2>
       <p class="info-text">
-      Aspine is a frontend service for Aspen to make it easier for students to
-      see and predict their grades. It allows you to predict grades if they
-      scored better on a test, or got an 100 on an upcoming project.
+      Aspine is a tool for CPSD students to make it easier to see and predict 
+      grades. It allows you to predict what your grades would be if you scored 
+      better on a test, or got an 100 on an upcoming project.
       </p>
       <h2 class="info-header">Editing Assignments</h2>
       <p class="info-text">
@@ -382,15 +382,16 @@
       <h2 class="info-header">Adding Assignments</h2>
       <p class="info-text">
       When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter
-      in a basic assignment in the first category, which you can change as you
-      so please to reflect possible upcoming assignments.
+      in a basic assignment in the currently selected category, which you can 
+      change however you like to reflect possible upcoming assignments.
       </p>
       <h2 class="info-header">Test Corrections</h2>
       <p class="info-text">
       When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can
       enter the percentage of points you could get back on test corrections.
       For example, if a teacher was allowing you to get 50% of your points
-      back, you could enter 50 and it will calculate your grade thusly.
+      back, you could enter 50 and it will calculate your grade with the 
+      points back.
       </p>
       <h2 class="info-header">Assignment Information</h2>
       <p class="info-text">
@@ -409,6 +410,13 @@
       the next school related thing happens, be it the start of the school day,
       the end of a class, or if it's already after school, just the normal
       time.
+      </p>
+      <h2 class="info-header">Importing/Exporting Grades</h2>
+      <p class="info-text">
+      When you click the download ( <i class="fa fa-file-download"></i> ) icon,
+      it lets you select what grades you want to export. These grades can be
+      imported later by clicking the <strong>Current Year</strong> dropdown 
+      menu and selecting <strong>Import Data</strong>.
       </p>
     </div>
   </div>

--- a/public/home.html
+++ b/public/home.html
@@ -72,6 +72,7 @@
     <!-- TODO: post-covid, setting lunch should be migrated to settings -->
     <!--<button class="tablinks" onclick="openTab(event, 'calendar-tab')">Calendar</button>-->
     <button class="tablinks" onclick="openTab(event, 'reports')" id="reports_open">Reports</button>
+    <button class="tablinks" onclick="openTab(event, 'information')" id="information_open">Info</button>
 <!--#ifndef lite-->
     <button class="tablinks tablinks-right" onclick="location.href='/logout'">Logout</button>
 <!--#endif-->
@@ -358,6 +359,27 @@
     <div id="pdf-container">
       <h1 id="pdf_loading_text"> Loading... </h1>
       <canvas id="pdf-canvas" width="400" height="400"></canvas>
+    </div>
+  </div>
+  <div id="information" , class="tabcontent">
+    <div id="instructions-header" style="text-align: left; ">
+      <!-- <h1 style="text-align: left;">Instructions</h1><br> -->
+      <p></p>
+      <p class="info-header">What is Aspine?</p>
+      Aspine is a frontend service for Aspen to make it easier for students to see and predict their grades. It allows you to predict grades if they scored better on a test, or got an 100 on an upcoming project.<br><br>
+      <p class="info-header">Editing Assignments</p>
+      Editing assignments is easy. In the <b>Grades</b> tab, select a class to see its categories and the individual assignemnt. If you select a category, it will filter the assignments by that category. Everything about an assignemnt is changeable. While this doesn't change the actual grades entered in aspen, it will show a predicted grade based off of what you entered. You can change assignemnt names, categories, scores and maximum scores.<br><br>
+      <p class="info-header">Adding Assignments</p>
+      When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter in a basic assignment in the first category, which you can change as you so please to reflect possible upcoming assignments.<br><br>
+      <p class="info-header">Test Corrections</p>
+      When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can enter the percentage of points you could get back on test corrections. For example, if a teacher was allowing you to get 50% of your points back, you could enter 50 and it will calculate your grade thusly.<br><br>
+      <p class="info-header">Assignment Information</p>
+      When you click the info ( <i class="fa fa-info"></i> ) icon, if your teacher allows it for your class, you can see statistics about how well you and your classmates did on that particular assignment.<br><br>
+      <p class="info-header">Report Cards</p>
+      In the <b>Reports</b> tab, you can see both current and past report cards.<br><br>
+      <p class="info-header">Clock</p>
+      The clock is a CRLS geared clock that tells you exactly how long until the next school related thing happens, be it the start of the school day, the end of a class, or if it's already after school, just the normal time.
+      </p>
     </div>
   </div>
   <p>Aspine version: <span id="version">(loading&hellip;)</span></p>

--- a/public/home.html
+++ b/public/home.html
@@ -365,24 +365,24 @@
     <div id="instructions-header" style="text-align: left">
       <h2 class="info-header">What is Aspine?</h2>
       <p class="info-text">
-      Aspine is a tool for CPSD students to make it easier to see and predict 
-      grades. It allows you to predict what your grades would be if you scored 
+      Aspine is a tool for CPSD students to make it easier to see and predict
+      grades. It allows you to predict what your grades would be if you scored
       better on a test, or got an 100 on an upcoming project.
       </p>
       <h2 class="info-header">Editing Assignments</h2>
       <p class="info-text">
       Editing assignments is easy. In the <strong>Grades</strong> tab, select a
-      class to see its categories and the individual assignemnt. If you select
+      class to see its categories and the individual assignment. If you select
       a category, it will filter the assignments by that category. Everything
-      about an assignemnt is changeable. While this doesn't change the actual
+      about an assignment is changeable. While this doesn't change the actual
       grades entered in aspen, it will show a predicted grade based off of what
-      you entered. You can change assignemnt names, categories, scores and
+      you entered. You can change assignment names, categories, scores and
       maximum scores.
       </p>
       <h2 class="info-header">Adding Assignments</h2>
       <p class="info-text">
       When you click the plus (<i class="fa fa-plus"></i>) icon, it will enter
-      in a basic assignment in the currently selected category, which you can 
+      in a basic assignment in the currently selected category, which you can
       change however you like to reflect possible upcoming assignments.
       </p>
       <h2 class="info-header">Test Corrections</h2>
@@ -390,7 +390,7 @@
       When you click the hammer (<i class="fa fa-hammer"></i>) icon, you can
       enter the percentage of points you could get back on test corrections.
       For example, if a teacher was allowing you to get 50% of your points
-      back, you could enter 50 and it will calculate your grade with the 
+      back, you could enter 50 and it will calculate your grade with the
       points back.
       </p>
       <h2 class="info-header">Assignment Information</h2>
@@ -415,16 +415,16 @@
       <p class="info-text">
       When you click the download ( <i class="fa fa-file-download"></i> ) icon,
       it lets you select what grades you want to export. These grades can be
-      imported later by clicking the <strong>Current Year</strong> dropdown 
+      imported later by clicking the <strong>Current Year</strong> dropdown
       menu and selecting <strong>Import Data</strong>.
       </p>
       <h2 class="info-header">GPA Type and Current Quarter</h2>
       When you click the <strong>GPA Type</strong> button, it switches between
       a normal 0-100 grade, an unweighted 0-4.0 GPA and a weighted 0-5.0 GPA.
-      When you clcik the <strong>Current Quarter</strong> dropdown, you can see
+      When you click the <strong>Current Quarter</strong> dropdown, you can see
       grades and assignments from other quarters.
       <p class="info-text">
-      
+
       </p>
     </div>
   </div>

--- a/public/home.html
+++ b/public/home.html
@@ -418,6 +418,14 @@
       imported later by clicking the <strong>Current Year</strong> dropdown 
       menu and selecting <strong>Import Data</strong>.
       </p>
+      <h2 class="info-header">GPA Type and Current Quarter</h2>
+      When you click the <strong>GPA Type</strong> button, it switches between
+      a normal 0-100 grade, an unweighted 0-4.0 GPA and a weighted 0-5.0 GPA.
+      When you clcik the <strong>Current Quarter</strong> dropdown, you can see
+      grades and assignments from other quarters.
+      <p class="info-text">
+      
+      </p>
     </div>
   </div>
   <p>Aspine version: <span id="version">(loading&hellip;)</span></p>


### PR DESCRIPTION
Closes #76. This is split out from pull request #157, which became unwieldy due to mixing the info tab feature (which seems to be ready to merge) with the tooltips (which may need a few more changes). Please refer to that pull request for more details.