### PR TITLE
Update district logo display

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -232,11 +232,20 @@ iframe {
   overflow: hidden;
 }
 
-#bottom-text {
+#bottom-text-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
   text-align: left;
-  margin: 5px 14px;
+  margin: 7.5px 17.5px;
 }
 
+#bottom-text {
+  float: left;
+}
+
+#bottom-text ul,
 #bottom-text li {
   display: inline;
 }
@@ -245,6 +254,12 @@ iframe {
   content: " | ";
   margin-left: 0.5em;
   margin-right: 0.5em;
+}
+
+#district-logo {
+  float: right;
+  max-height: 45px;
+  vertical-align: baseline;
 }
 
 /*------------------------------------------------------------------
@@ -433,6 +448,20 @@ iframe {
   #login100-form {
     width: 50%;
   }
+
+  #bottom-text-container {
+    flex-direction: column;
+  }
+
+  #bottom-text {
+    align-self: center;
+    text-align: center;
+  }
+
+  #district-logo {
+    align-self: center;
+    margin-top: 7.5px;
+  }
 }
 
 @media (max-width: 768px) {
@@ -446,10 +475,6 @@ iframe {
 
   #login100-form {
     width: 100%;
-  }
-
-  #bottom-text {
-    text-align: center;
   }
 }
 

--- a/public/login.html
+++ b/public/login.html
@@ -89,28 +89,28 @@
                     Login
                   </button>
                 </div>
-                <div class="text-center">
-                  <img src="images/district-logo.png" style="width:75%">
-                </div>
             </form>
           </div>
 
-          <span id="bottom-text">
-            <ul>
-              <li>
-                <a href="https://goo.gl/forms/PYQDtzkp0vHJbFLz2">Issue/Feature Requests</a>
-              </li>
-              <li>
-                <a href="https://github.com/Aspine/aspine">Our GitHub Repository</a>
-              </li>
-              <li>
-                <a href="https://www.cpsd.us/privacy">Privacy Policy</a>
-              </li>
-              <li>
-                <a href="mailto:crls-ctf-club-usergroup@cpsd.us">Join Our Club</a>
-              </li>
-            </ul>
-          </span>
+          <div id="bottom-text-container">
+            <span id="bottom-text">
+              <ul>
+                <li>
+                  <a href="https://goo.gl/forms/PYQDtzkp0vHJbFLz2">Issue/Feature Requests</a>
+                </li>
+                <li>
+                  <a href="https://github.com/Aspine/aspine">Our GitHub Repository</a>
+                </li>
+                <li>
+                  <a href="https://www.cpsd.us/privacy">Privacy Policy</a>
+                </li>
+                <li>
+                  <a href="mailto:crls-ctf-club-usergroup@cpsd.us">Join Our Club</a>
+                </li>
+              </ul>
+            </span>
+            <img id="district-logo" src="images/district-logo.png">
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Update the way that the district logo, if present, displays on the login page.

Screenshots, grouped by viewport width:

<details>
<summary>425px</summary>

| Before | After |
| -- | -- |
| ![425-before](https://user-images.githubusercontent.com/45520974/102539243-70a5c800-407b-11eb-8deb-4aa82e385938.png) | ![425-after](https://user-images.githubusercontent.com/45520974/102539385-9df27600-407b-11eb-9c10-1143710e9aa5.png) |

</details>
<details>
<summary>720px</summary>

| Before | After |
| -- | -- |
| ![720-before](https://user-images.githubusercontent.com/45520974/102539747-16f1cd80-407c-11eb-942b-e97bb2feb98a.png) | ![720-after](https://user-images.githubusercontent.com/45520974/102539752-18bb9100-407c-11eb-95ed-fe037d0434bc.png) |

</details>
<details>
<summary>800px</summary>

| Before | After |
| -- | -- |
| ![800-before](https://user-images.githubusercontent.com/45520974/102540023-7354ed00-407c-11eb-8297-7d9c7d240d23.png) | ![800-after](https://user-images.githubusercontent.com/45520974/102540045-78b23780-407c-11eb-92c6-52adbbe40f05.png) |

</details>
<details>
<summary>1024px</summary>

| Before | After |
| -- | -- |
| ![1024-before](https://user-images.githubusercontent.com/45520974/102540197-adbe8a00-407c-11eb-8ff5-ae3110277572.png) | ![1024-after](https://user-images.githubusercontent.com/45520974/102540203-af884d80-407c-11eb-8d24-8a629f630740.png) |


</summary>