### PR TITLE
Improve session handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -835,6 +835,15 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "material-icons": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-0.5.1.tgz",
@@ -844,6 +853,30 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memorystore": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.4.tgz",
+      "integrity": "sha512-51j4kUedbqkWGby44hAhf5f/hj8GOvHoLX00/YHURBNxOMf5k8JbPuGfmeNpZEXhc3vrmfnFben4+rOOx3HjEQ==",
+      "requires": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -978,6 +1011,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
@@ -1383,6 +1421,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jquery": "^3.5.1",
     "jsdom": "^16.4.0",
     "material-icons": "^0.5.1",
+    "memorystore": "^1.6.4",
     "minimist": "^1.2.5",
     "node-fetch": "^2.6.1",
     "pdfjs-dist": "^2.5.207",

--- a/serve.js
+++ b/serve.js
@@ -7,9 +7,8 @@ const express = require('express');
 const scraper = require('./scrape.js');
 const bodyParser = require('body-parser');
 const session = require('express-session');
-// const RedisStore = require('connect-redis')(session);
-// const redis = require("redis"),
-//     client = redis.createClient(6310);
+const MemoryStore = require('memorystore')(session)
+const crypto = require('crypto');
 const http = require('http');
 const fs = require('fs');
 const https = require('https');
@@ -197,10 +196,14 @@ app.use(express.static(__dirname + '/public'));
 app.use(bodyParser.urlencoded({ extended: true })); // Allows form submission
 app.use(bodyParser.json()); // json parser
 app.use(session({
-    // store: new RedisStore(options),
-    secret: 'scheming+anaconda+bunkbed+greeting+octopus+ultimate+viewable+hangout+everybody',
+    cookie: { maxAge: 28800000 },
+    store: new MemoryStore({ checkPeriod: 28800000 }),
+    // Sessions expire every 8 hours (28800000 ms)
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    secret: crypto.randomBytes(64).toString('hex'),
+    // Sessions are destroyed on restarting the server anyway (because we use
+    // MemoryStore), so the secret can be random
 }));
 
 app.post('/stats', async (req, res) => {


### PR DESCRIPTION
Fixes #218. Use [lru-cache](https://github.com/isaacs/node-lru-cache) (via `memorystore` package on npm) instead of Express's built-in `MemoryStore` which is [known for memory leaks](http://expressjs.com/en/resources/middleware/session.html), use a random secret instead of a hard-coded one, and make sessions expire after 8 hours.