### PR TITLE
Disable service worker code (for now)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,4 @@
+/*
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js').then(registration => {
@@ -9,3 +10,4 @@ if ('serviceWorker' in navigator) {
     });
   });
 }
+*/


### PR DESCRIPTION
Currently `sw.js` does nothing except for throw errors in the console. While it is certainly a laudable goal to make Aspine a true PWA, this should be done separately and we do not need a stub throwing errors until we do that.