### PR TITLE
Remove shebang lines from scrape/serve

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -1,7 +1,3 @@
-#!/bin/sh
-':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
-// https://unix.stackexchange.com/a/65295
-
 // --------------- Parameters ----------------
 // Multi-Threads
 const CLASS_THREADS = 12;

--- a/serve.js
+++ b/serve.js
@@ -1,14 +1,9 @@
-#!/bin/sh
-':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
-// https://unix.stackexchange.com/a/65295
-
-
 const express = require('express');
 const { program } = require('commander');
 const scraper = require('./scrape.js');
 const bodyParser = require('body-parser');
 const session = require('express-session');
-const MemoryStore = require('memorystore')(session)
+const MemoryStore = require('memorystore')(session);
 const crypto = require('crypto');
 const fs = require('fs');
 const https = require('https');


### PR DESCRIPTION
Because the recommended way to start the Aspine server is `npm start` and not `./serve.js` (especially in light of the oncoming move to the new REST API scraper), there is no use in having shebang lines in `serve.js` or `scrape.js` (particularly considering that the `#!/bin/sh` shebang is hacky and may confuse some editors, causing them to treat these files as shell scripts).

Also, this commit adds a semicolon to an import in `serve.js`.