### PR TITLE
fixes sidenav overlay bug

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1244,3 +1244,15 @@ p#large_clock_period {
   visibility: hidden;
   /* cursor: pointer; */
 }
+
+#sidenav-overlay.fade-in {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 300ms 0ms, visibility 0ms 0ms;
+}
+
+#sidenav-overlay.fade-out {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 300ms 0ms, visibility 0ms 300ms;
+}

--- a/public/home.html
+++ b/public/home.html
@@ -45,7 +45,7 @@
   <script src="vendor/d3/d3-boxplot.min.js" defer></script>
 </head>
 <body>
-  <div id="sidenav-overlay" class="fade-in"></div>
+  <div id="sidenav-overlay"></div>
   <noscript>
     <p><strong>
       Aspine is designed to work mainly as a client-side web application

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1178,16 +1178,26 @@ function openTab(evt, tab_name) {
 function openSideNav() {
     const sidenav = document.getElementById("sidenav");
     sidenav.style.width = sidenav.clientWidth === 270 ? "0px" : "270px";
-    // greys out the main section
-    const mainSection = $("#sidenav-overlay");
-    mainSection.css("visibility", "visible");
-    $(mainSection).fadeIn("slow");
+
+    // makes sidenav overlay fade out
+    const sidenavOverlay = document.getElementById("sidenav-overlay")
+    if (sidenavOverlay.classList.contains("fade-out")) {
+        sidenavOverlay.classList.remove("fade-out")
+    }
+    sidenavOverlay.classList.add("fade-in")
 }
 
 function closeSideNav() {
-    document.getElementById("sidenav").style.width = "0px";
-    const mainSection = $(".sidenav-overlay");
-    $(mainSection).fadeOut("slow");
+    const sidenav = document.getElementById("sidenav")
+    sidenav.style.width = "0px";
+
+    // makes sidenav overlay fade in
+    const sidenavOverlay = document.getElementById("sidenav-overlay")
+    if (sidenavOverlay.classList.contains("fade-in")) {
+        sidenavOverlay.classList.remove("fade-in")
+    }
+    sidenavOverlay.classList.add("fade-out")
+    
 }
 
 //  Allows exiting sidenav by clicking anywhere outside


### PR DESCRIPTION
Somehow someone accidentally changed the . to a # in the closeSidenav function so it just stays there so I fixed that. Also I switched the animations from jquery animations to CSS ones becuase those do really well when they're interrupted whereas the jquery ones do not. Also switched from jqueries to normal dom stuff for notrodes' sanity and consistancy within the function.