### PR TITLE
Use NODE_ENV to detect production/development

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ downloaded Aspine, and run `npm install`.
   + On Windows, double-click on the script `npminstall.bat`. The `.bat` file
 extension may be invisible depending on your system configuration.
 
-- Start the Aspine server by running `npm start -- -i` in a terminal window (or
+- Start the Aspine server by running `npm start` in a terminal window (or
   Command Prompt on Windows). If you are on a Unix-like system, you can run
-  `npm start -- -i &` to run the server in the background and then run
+  `npm start &` to run the server in the background and then run
   `killall node` when you want to kill the server.
 
 ## Authors

--- a/restart-serve.sh
+++ b/restart-serve.sh
@@ -1,2 +1,2 @@
 sudo pkill "node"
-sudo $NVM_BIN/npm start &
+sudo NODE_ENV=production $NVM_BIN/npm start &

--- a/serve.js
+++ b/serve.js
@@ -17,10 +17,25 @@ const version = child_process.execSync('git describe')
 
 program
     .version(version)
-    .option('-i, --insecure', 'do not secure connections with TLS (HTTPS)')
     .option('-p, --port <number>', 'port to listen on', 8080)
-    .option('-P, --port-https <number>', 'port to listen on for HTTPS', 4430)
-    .parse();
+    .option('-P, --port-https <number>', 'port to listen on for HTTPS', 4430);
+
+// Secure by default on production, insecure by default for development
+if (process.env.NODE_ENV === "production") {
+    program.option('-i, --no-secure, --insecure',
+        'do not secure connections with TLS (HTTPS)'
+    );
+    program.option('-s, --secure',
+        'secure connections with TLS (HTTPS) [default for production]'
+    );
+} else {
+    program.option('-s, --secure', 'secure connections with TLS (HTTPS)');
+    program.option('-i, --no-secure, --insecure',
+        'do not secure connections with TLS (HTTPS) [default for development]'
+    );
+}
+
+program.parse();
 
 // ------------ Web Server -------------------
 const app = express();
@@ -29,7 +44,7 @@ app.listen(program.port, () =>
     console.log(`Aspine listening on port ${program.port}!`)
 );
 
-if (!program.insecure) {
+if (program.secure) {
     app.all('*', (req, res, next) => {
         if (req.secure) {
             return next();

--- a/start-local.sh
+++ b/start-local.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# redis-server redis.conf &
-node ./serve.js insecure &

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm start -- -i

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-npm start -- -i


### PR DESCRIPTION
Following the changes to the CLI in pull request #233, bring back the `start.sh` script to minimize confusion.