### PR TITLE
Fix schedule + clock for semester 2

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -278,11 +278,12 @@
   </div>
   <div id="schedule" class="tabcontent">
     <!-- Rounded switch -->
-    <label class="switch">
+    <!-- Black/silver switch disabled due to covid-19 schedule -->
+    <!--<label class="switch">
       <input type="checkbox" id="schedule_toggle" onclick="schedule_toggle();">
       <span class="slider round"></span>
       <p id="schedule_title" class="unselectable">Black</p>
-    </label>
+    </label>-->
     <div id="scheduleTable"></div>
   </div>
   <div id="clock" class="tabcontent">

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -17,7 +17,7 @@ logo = document.getElementById("logo");
 
 // Controls whether to use the covid-19 schedule or the regular schedule
 const covid_schedule = true;
-let current_schedule = covid_schedule ? "covid" : "regular";
+let current_schedule = covid_schedule ? "covid-mt" : "regular";
 
 // For testing.
 // If this is set to a valid date/time string, that will be used instead of the
@@ -120,10 +120,7 @@ function fitText(ctx, text, fontface, width) {
 }
 
 function update_lunch() {
-    if (covid_schedule) {
-        current_schedule = "covid";
-    }
-    else {
+    if (!covid_schedule) {
         switch(Number(document.getElementById("lunch_range").value)) {
             case 0:
             current_schedule = "regular-a";
@@ -190,7 +187,7 @@ function get_period_name(default_name) {
 
 function redraw_clock() {
     // Fake call to get_period_name to set current_schedule
-    get_period_name("Period 1");
+    // get_period_name("Period 1");
     let number = 0;
     let period_name = "";
     const now = date_override ? new Date(date_override) : new Date();
@@ -200,9 +197,7 @@ function redraw_clock() {
         + now.getSeconds() * 1000
         + now.getMilliseconds();
     let pos;
-    // TODO 2021-01-27: this is a temporary fix until we support the semester 2
-    // schedule
-    if (false /*![0, 6].includes(now.getDay())*/) {
+    if (![0, 6].includes(now.getDay())) {
         // School day
         let current_period_i = 0;// Get current period from array
         while (current_period_i < schedules[current_schedule].length - 1 &&

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -222,17 +222,13 @@ function redraw_clock() {
         const current_period = schedules[current_schedule][current_period_i];
         const next_period = schedules[current_schedule][current_period_i + 1];
 
-        if (tod < current_period.start) { // Before school
-            period_name = "Before School";
-            pos = tod / current_period.start;
-            number = current_period.start - tod;
-        }
-        else if (!next_period && tod > current_period.end) { // After school
+        if (tod < current_period.start ||
+            (!next_period && tod > current_period.end)) {
             // Realtime
             period_name = "";
             pos = tod % (12 * 60 * 60 * 1000) / (12 * 60 * 60 * 1000);
             number = tod % (12 * 60 * 60 * 1000);
-            if(number < 1 * 60 * 60 * 1000) {
+            if (number < 1 * 60 * 60 * 1000) {
                 number += 12 * 60 * 60 * 1000;
             }
         }

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -154,7 +154,7 @@ function get_schedule(p3room, p3id) {
 
 // Takes the default names (Period 1, etc) and overrides with real class
 // names if they are available
-function get_period_name(default_name) {
+function get_period_name(default_name, day_of_week) {
     if (typeof(currentTableData) === "undefined"
     || Object.keys(currentTableData).length === 0
     || typeof(currentTableData.schedule) === "undefined"
@@ -174,9 +174,23 @@ function get_period_name(default_name) {
             current_schedule = get_schedule(period_names.black[2].room, period_names.black[2].id);
         }
     }
-    let bs_day = document.getElementById("schedule_title").innerHTML.toLowerCase();
+    let bs_day;
+    if (covid_schedule) {
+        bs_day = [1, 4].includes(day_of_week) ? "silver" : "black";
+
+        // Determine which covid schedule to use
+        if ([1, 2].includes(day_of_week)) {
+            current_schedule = "covid-mt";
+        } else if ([4, 5].includes(day_of_week)) {
+            current_schedule = "covid-rf";
+        } else {
+            current_schedule = "covid-w";
+        }
+    } else {
+        bs_day = document.getElementById("schedule_title").innerHTML
+            .toLowerCase();
+    }
     // period_names has class names now
-    let block;
     for (const { name, period } of period_names[bs_day]) {
         if (period === default_name
             || period === `BLOCK ${default_name.slice(-1)}`)
@@ -186,11 +200,11 @@ function get_period_name(default_name) {
 }
 
 function redraw_clock() {
+    const now = date_override ? new Date(date_override) : new Date();
     // Fake call to get_period_name to set current_schedule
-    // get_period_name("Period 1");
+    get_period_name("Period 1", now.getDay());
     let number = 0;
     let period_name = "";
-    const now = date_override ? new Date(date_override) : new Date();
     // Time of day
     const tod = now.getHours() * 60 * 60 * 1000
         + now.getMinutes() * 60 * 1000
@@ -223,13 +237,13 @@ function redraw_clock() {
             }
         }
         else if (tod > current_period.end) { // Between classes
-            period_name = get_period_name(current_period.name) +
-            " ➡ " + get_period_name(next_period.name);
+            period_name = get_period_name(current_period.name, now.getDay()) +
+            " ➡ " + get_period_name(next_period.name, now.getDay());
             pos = (tod - current_period.end) / (next_period.start - current_period.end);
             number = next_period.start - tod;
         }
         else { // In class
-            period_name = get_period_name(current_period.name);
+            period_name = get_period_name(current_period.name, now.getDay());
             pos = (tod - current_period.start) / (current_period.end - current_period.start);
             number = current_period.end - tod;
         }

--- a/public/schedule.json
+++ b/public/schedule.json
@@ -1,5 +1,10 @@
 {
     "regular":[
+		{
+			"name": "Before School",
+			"start": 2430000,
+			"end": 2790000
+		},
         {
             "name":"Period 1",
             "start": 29100000,
@@ -37,6 +42,11 @@
         }
     ],
     "regular-a":[
+		{
+			"name": "Before School",
+			"start": 2430000,
+			"end": 2790000
+		},
         {
             "name":"Period 1",
             "start": 29100000,
@@ -69,6 +79,11 @@
         }
     ],
     "regular-b":[
+		{
+			"name": "Before School",
+			"start": 2430000,
+			"end": 2790000
+		},
         {
             "name":"Period 1",
             "start": 29100000,
@@ -106,6 +121,11 @@
         }
     ],
     "regular-c":[
+		{
+			"name": "Before School",
+			"start": 2430000,
+			"end": 2790000
+		},
         {
             "name":"Period 1",
             "start": 29100000,
@@ -138,6 +158,11 @@
         }
     ],
     "covid":[
+		{
+			"name": "Before School",
+			"start": 27300000,
+			"end": 30300000
+		},
         {
             "name":"Period 1",
             "start": 33000000,
@@ -165,6 +190,11 @@
         }
     ],
 	"covid-mt": [
+		{
+			"name": "Before School",
+			"start": 25200000,
+			"end": 30300000
+		},
 		{
 			"name": "Period 1",
 			"start": 30900000,
@@ -209,6 +239,11 @@
 		}
 	],
 	"covid-rf": [
+		{
+			"name": "Before School",
+			"start": 25200000,
+			"end": 30300000
+		},
 		{
 			"name": "Period 3",
 			"start": 30900000,

--- a/public/schedule.json
+++ b/public/schedule.json
@@ -163,5 +163,81 @@
             "start": 46800000,
             "end": 49800000
         }
-    ]
+    ],
+	"covid-mt": [
+		{
+			"name": "Period 1",
+			"start": 30900000,
+			"end": 35700000
+		},
+		{
+			"name": "Period 2",
+			"start": 36300000,
+			"end": 41100000
+		},
+		{
+			"name": "Study Support",
+			"start": 41700000,
+			"end": 44100000
+		},
+		{
+			"name": "Lunch",
+			"start": 44100000,
+			"end": 47700000
+		},
+		{
+			"name": "Period 3",
+			"start": 47700000,
+			"end": 50700000
+		},
+		{
+			"name": "Period 4",
+			"start": 51000000,
+			"end": 54000000
+		}
+	],
+	"covid-w": [
+		{
+			"name": "Community Meeting",
+			"start": 34500000,
+			"end": 36000000
+		},
+		{
+			"name": "Advisory",
+			"start": 49800000,
+			"end": 54000000
+		}
+	],
+	"covid-rf": [
+		{
+			"name": "Period 3",
+			"start": 30900000,
+			"end": 35700000
+		},
+		{
+			"name": "Period 4",
+			"start": 36300000,
+			"end": 41100000
+		},
+		{
+			"name": "Study Support",
+			"start": 41700000,
+			"end": 44100000
+		},
+		{
+			"name": "Lunch",
+			"start": 44100000,
+			"end": 47700000
+		},
+		{
+			"name": "Period 1",
+			"start": 47700000,
+			"end": 50700000
+		},
+		{
+			"name": "Period 2",
+			"start": 51000000,
+			"end": 54000000
+		}
+	]
 }

--- a/scrape.js
+++ b/scrape.js
@@ -1005,6 +1005,11 @@ async function scrape_schedule(username, password) {
                     return textarea.value;
                 });
                 const aspenPeriod = periods[i];
+
+                if (name === "Study Support") {
+                    return undefined;
+                }
+
                 return { id, name, teacher, room, aspenPeriod };
             }
         }).filter(isScheduleItem)


### PR DESCRIPTION
This pull request makes some changes to the backend and the frontend to
adapt to the semester 2 schedule. On the backend, it excludes the Study
Support block from being counted as a class so that it can be included
on the frontend. On the frontend, a few changes have been made:
- Update `schedule.json` to include the new schedule (Monday/Tuesday,
  Wednesday, and Thursday/Friday variations)
- Use the Monday/Tuesday variation of the new schedule instead of the
  old schedule
- Re-enable period name detection

To do:
- [x] Detect the day of the week and use this to select the appropriate
  variation of the schedule as well as black/silver
- [ ] Replace the black/silver slider on the schedule tab with a
  day-of-week picker
- [ ] Change the schedule display to be more in line with the
  progression of the day as well as how the schedule is displayed on
  Aspen (we could draw from `schedule.json` for the order of periods as
  well as times)
