### PR TITLE
Show release notes back to last minor version

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1252,17 +1252,26 @@ $.ajax("/version").then(ver => $("#version").text(ver));
 $.ajax("/updates").then(upt => {
     $("#updates").html(upt);
     document.getElementById("changelog").outerHTML = "<h2 class='info-header'>Version History/What's New:</h2>";
-    const items = [...document.querySelectorAll("#updates h2")];
-    items.forEach(x => { x.className = "info-header"; });
-    //Hide Everything but first and second versions
-    items.slice(4).forEach(x => { x.style.setProperty("display", "none") });
-    const subpoints = [...document.querySelectorAll("#updates ul")];
-    subpoints.slice(3).forEach(x => { x.style.setProperty("display", "none") });
 
-    //Removes first two paragraphs with "Semantic versioning info"
-    const paras = [...document.querySelectorAll("#updates p")];
-    paras.slice(0,2).forEach(x => { x.style.setProperty("display", "none") });
+    // Hide all versions prior to the current minor version
+    const items = document.querySelectorAll("#updates h2:nth-of-type(n+2)");
+    const current_version = document.querySelector("#version").textContent;
+    const [, curMajor, curMinor] = current_version.match(/^v?(\d+)\.(\d+)/);
+    items.forEach(x => {
+        const [, major, minor] = x.textContent.match(/^v?(\d+)\.(\d+)/);
+        if (parseInt(minor) < parseInt(curMinor)
+                || parseInt(major) < parseInt(curMajor)) {
+            x.style.setProperty("display", "none");
+            x.nextElementSibling.style.setProperty("display", "none");
+        } else {
+            x.classList.add("info-header")
+        }
+    });
 
+    // Remove first two paragraphs with information about semver
+    document.querySelectorAll("#updates p:nth-of-type(n-2)").forEach(x => {
+        x.style.setProperty("display", "none");
+    });
 });
 
 //#endif


### PR DESCRIPTION
Closes #264. Instead of having the changelog code be hard-coded to show the past three versions' release notes, go by minor version numbers instead; that is, display release notes back to the latest minor version release (2.5.0, 2.6.0, etc.).