### PR TITLE
Fix "(NaN%)" bug for categories

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -311,15 +311,14 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
             title: "Category",
             field: "category",
             editor: "select",
-            editorParams: function(cell) {
-                let catCategories = [];
-
-                for (let category of Object.keys(currentTableData.currentTermData.classes[selected_class_i].categories))
-                    catCategories.push(`${category} (${category * 100}%)`);
-                return {values: catCategories};
-            },
-            formatter: rowFormatter,
-            headerSort: false,
+            editorParams: cell => ({
+                values: Object.entries(
+                    currentTableData.currentTermData
+                    .classes[selected_class_i].categories
+                ).map(([cat, weight]) =>
+                    `${cat} (${parseFloat(weight) * 100}%)`
+                )
+            }),
         },
         {
             title: "Score",


### PR DESCRIPTION
In the assignments table, editing the category of an assignment opened a dropdown where each category was listed as `${category} (NaN%)`; this has been fixed to show the weight of each category.