### PR TITLE
Show classes for study support, remove dummy classes

### DIFF
--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -232,6 +232,28 @@ function get_period_name(default_name, day_of_week) {
         bs_day = document.getElementById("schedule_title").innerHTML
             .toLowerCase();
     }
+
+    if (default_name === "Study Support") {
+        // Number of period whose study support block is today
+        let block = 0;
+        switch (day_of_week) {
+            case 1:
+            case 2:
+                block = day_of_week;
+                break;
+            case 4:
+            case 5:
+                block = day_of_week - 1;
+                break;
+        }
+        for (const { name, period } of period_names[bs_day]) {
+            if (period.includes(block)) {
+                return name;
+            }
+        }
+        return default_name;
+    }
+
     // period_names has class names now
     for (const { name, period } of period_names[bs_day]) {
         if (period === default_name)

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -51,6 +51,10 @@ export async function get_student(
       if (!details.grades.has(quarter)) {
         return undefined;
       }
+      // exclude classes that don't recieve grades in Aspen
+      if (["Study Support", "Advisory", "Community Meeting", "PE Athletics", "PE 10-12 Wellness Elective"].includes(details.name)) {
+        return undefined;
+      }
 
       let categories: { [key: string]: string } = {};
       for (const [cat, { weight} ] of details.categories) {

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -52,8 +52,10 @@ export async function get_student(
         return undefined;
       }
       // exclude classes that don't recieve grades in Aspen
-      if (["Study Support", "Advisory", "Community Meeting", "PE Athletics", 
-      "PE 10-12 Wellness Elective"].includes(details.name)) {
+      if ([
+        "Study Support", "Advisory", "Community Meeting", "PE Athletics",
+        "PE 10-12 Wellness Elective",
+      ].includes(details.name)) {
         return undefined;
       }
 

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -52,7 +52,8 @@ export async function get_student(
         return undefined;
       }
       // exclude classes that don't recieve grades in Aspen
-      if (["Study Support", "Advisory", "Community Meeting", "PE Athletics", "PE 10-12 Wellness Elective"].includes(details.name)) {
+      if (["Study Support", "Advisory", "Community Meeting", "PE Athletics", 
+      "PE 10-12 Wellness Elective"].includes(details.name)) {
         return undefined;
       }
 


### PR DESCRIPTION
Closes #259, Closes #265. Use the day of the week to determine the class corresponding to the study support block. 
Also removes Study Support and other ungraded classes from the Grades tab.