### PR TITLE
Clarify license to be GPLv3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,16 @@ Copyright
 [Aspine contributors](https://github.com/Aspine/aspine/graphs/contributors)
 2019&ndash;21.
 
-This software is licensed under the GNU General Public License, version 3
-&mdash; see the [LICENSE.md](LICENSE.md) file for details.
+Aspine is [free/libre](https://www.gnu.org/philosophy/free-sw.html) and
+[open-source](https://opensource.org/osd) software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
 
-If you contribute to Aspine, please note that you are consenting to having your
-contributions released under the terms of this license. For any contributions
-dated on or after October 23, 2020, you also consent to having your
-contributions be released under any earlier or later version of the GNU General
-Public License, as published by the Free Software Foundation, if and when the
-licensing terms for Aspine are changed to allow such version(s). (For more
-information about the rationale behind this clause, please read issue
-[#38](https://github.com/Aspine/aspine/issues/38).)
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License (version 3)
+along with this program (see file `LICENSE.md`).  If not, see
+<https://www.gnu.org/licenses/>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "aspine",
       "version": "2.8.1",
-      "license": "GPL-3.0-only",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/maxtkc/aspine/issues"
   },
-  "license": "GPL-3.0-only",
+  "license": "GPL-3.0-or-later",
   "contributors": [
     "Max Katz-Christy",
     "Cole Killian",


### PR DESCRIPTION
Closes #38. This PR clarifies that Aspine's license is GPLv3 _or any later version_; please see #38 for the rationale. Because Aspine has multiple contributors, this change does not go into effect until all copyright holders who have contributed prior to October 23, 2020<sup>1</sup> (@Ruborcalor, @psvenk, @maxtkc, @notrodes, @kdk1616, @tektaxi, @andOrlando) have approved this, so I ask everyone to please hold off from merging this until the approval of all of these people is secured.

Please add a comment or review verifying your assent (or dissent) and check the corresponding box.

- [x] @Ruborcalor
- [x] @psvenk
- [ ] @maxtkc 
- [x] @notrodes 
- [x] @kdk1616 
- [x] @tektaxi 
- [x] @andOrlando 

<sup>1</sup> This includes any changes that are substantial enough to be eligible for copyright. The cutoff date comes from f1f73fcb5f (by which all contributions since that date are licensed under all versions of the GPL; contributions made after this is merged will be licensed specifically under GPLv3+).