### PR TITLE
Use CSS variables in getColor

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -62,6 +62,7 @@ body {
   --purple: #e9a1ff;
 
   --orange: #f6b93b;
+  --orange1: #ff6b00;
 
   --red: #ff0000;
   --red1: #a70000;
@@ -105,6 +106,7 @@ body.dark {
   --purple: #e9a1ff;
 
   --orange: #f6b93b;
+  --orange1: #ff6b00;
 
   --red: #ff0000;
   --red1: #ff8585;

--- a/public/js/buttonFunctions.js
+++ b/public/js/buttonFunctions.js
@@ -12,7 +12,7 @@ let newAssignment = function() {
         "score": 10,
         "max_score": 10,
         "percentage": 100,
-        "color": "green",
+        "color": "var(--green)",
         "synthetic": "true",
       });
     newAssignmentIDCounter++;

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -226,6 +226,8 @@ function getColor(gradeToBeColored) {
     return "var(--blue)";
   } else if (parseFloat(gradeToBeColored) >= 69.5) {
     return "var(--orange)";
+  } else if (parseFloat(gradeToBeColored) >= 59.5) {
+    return "var(--orange1)";
   } else if (parseFloat(gradeToBeColored) >= 0) {
     return "var(--red)";
   } else {

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -221,17 +221,15 @@ function getColor(gradeToBeColored) {
   }
 
   if (parseFloat(gradeToBeColored) >= 89.5) {
-    return "#1E8541";
+    return "var(--green1)";
   } else if (parseFloat(gradeToBeColored) >= 79.5) {
-    return "#6666FF";
+    return "var(--blue)";
   } else if (parseFloat(gradeToBeColored) >= 69.5) {
-    return "#ff9900";
-  } else if (parseFloat(gradeToBeColored) >= 59.5) {
-    return "orange";
+    return "var(--orange)";
   } else if (parseFloat(gradeToBeColored) >= 0) {
-    return "red";
+    return "var(--red)";
   } else {
-    return "black";
+    return "var(--black)";
   }
 }
 


### PR DESCRIPTION
Instead of hard-coding colors, use CSS variables so that grades are
more visible in dark mode.