### PR TITLE
Add support for previous year grades

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -114,6 +114,7 @@
       <select id="tableData_select">
         <option value="0">Current Year</option>
         <option value="0">Current Year</option>
+        <option value="1">Previous Year</option>
         <option value="import">Import Data...</option>
       </select>
     </div>

--- a/public/js/buttonFunctions.js
+++ b/public/js/buttonFunctions.js
@@ -352,7 +352,10 @@ let exportTableData = async function(prefs) {
             const response = await $.ajax({
               url: "/data",
               method: "POST",
-              data: { quarter: parseInt(term.match(/\d+/)[0]) },
+              data: {
+                quarter: parseInt(term.match(/\d+/)[0]),
+                year: "current",
+              },
               dataType: "json json"
             });
             currentTerm = term;
@@ -437,7 +440,7 @@ let importTableData = async function(obj) {
     + `https://github.com/Aspine/aspine/releases</a>.`;
   }
 
-  currentTableDataIndex++;
+  currentTableDataIndex = tableData.length;
   tableData[currentTableDataIndex] = {};
   currentTableData = tableData[currentTableDataIndex];
   currentTableData.type = "imported";
@@ -510,6 +513,16 @@ let importTableData = async function(obj) {
       tableData[0].name;
     $("#tableData_select-items-0")[0].textContent =
       tableData[0].name;
+
+    // Remove "Previous Year" option
+    $("#tableData_select option[value='1']")[0].remove();
+    $("#tableData_select-items-1").remove();
+  } else if (currentTableDataIndex === 1) {
+    // Modify the text of the existing "Previous Year" option
+    $("#tableData_select option[value='1']")[1].textContent =
+      tableData[1].name;
+    $("#tableData_select-items-1")[1].textContent =
+      tableData[1].name;
   }
 
   $(`#tableData_select-items-${currentTableDataIndex}`).click();

--- a/public/js/buttonFunctions.js
+++ b/public/js/buttonFunctions.js
@@ -341,7 +341,10 @@ let exportTableData = async function(prefs) {
           return currentTableData.terms[term];
         }
         // Term is selected by user and its data have not been downloaded
-        else if (prefs.terms[term] && !currentTableData.imported) {
+        else if (
+          prefs.terms[term] && !currentTableData.imported /* backwards compat */
+          && currentTableData.type !== "imported"
+        ) {
           try {
             $("#export_status").html(
               `Downloading quarter "${term}" from Aspen&hellip;`
@@ -437,7 +440,7 @@ let importTableData = async function(obj) {
   currentTableDataIndex++;
   tableData[currentTableDataIndex] = {};
   currentTableData = tableData[currentTableDataIndex];
-  currentTableData.imported = true;
+  currentTableData.type = "imported";
   currentTableData.name = obj.name;
 
   let includedTerms = {};

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -918,6 +918,14 @@ let listener = function({ target }, callback = () => {}) {
             q3: {},
             q4: {},
           };
+
+          // For the previous year (where there is no "current" quarter),
+          // prepopulate the GPA object with dummy data
+          if (currentTableData.type === "previous") {
+            currentTableData.terms.current.GPA = {
+              percent: NaN, outOfFour: NaN, outOfFive: NaN,
+            };
+          }
         }
 
         if (typeof currentTableData.currentTermData === 'undefined') {
@@ -1169,7 +1177,9 @@ let tableData_option_onclick = function() {
     case "imported":
       // Get the first term included in the imported data
       for (term of termConverter) {
-        if (currentTableData.terms[term] && currentTableData.terms[term].GPA) {
+        if (currentTableData.terms[term]
+            && currentTableData.terms[term].GPA
+            && !isNaN(currentTableData.terms[term].GPA.percent)) {
           selTerm = term;
           break;
         }

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -886,17 +886,18 @@ let initialize_pdf_dropdown = function() {
 
 }
 
-let listener = function(event, callback = () => {}) {
-  let _this = event.target;
+// Switch terms
+// callback is a function to run once the data have been loaded
+let listener = function({ target }, callback = () => {}) {
   /* When an item is clicked, update the original select box,
   and the selected item: */
 
   if (term_dropdown_active) {
     let y, i, k, s, h;
-    s = _this.parentNode.parentNode.getElementsByTagName("select")[0];
-    h = _this.parentNode.previousSibling;
+    s = target.parentNode.parentNode.getElementsByTagName("select")[0];
+    h = target.parentNode.previousSibling;
     for (i = 0; i < s.length; i++) {
-      if (s.options[i].innerHTML === _this.innerHTML) {
+      if (s.options[i].innerHTML === target.innerHTML) {
         if (i === 0) {
           currentTerm = termConverter[i];
         } else {
@@ -937,7 +938,7 @@ let listener = function(event, callback = () => {}) {
             dataType: "json json",
             success: response => {
               responseCallbackPartial(response);
-              callback(response);
+              callback();
             },
           });
 
@@ -947,12 +948,12 @@ let listener = function(event, callback = () => {}) {
           $("#categoriesTable").hide(); //;.setData(tableData[i].assignments);
 
           s.selectedIndex = i;
-          h.innerHTML = _this.innerHTML;
-          y = _this.parentNode.getElementsByClassName("same-as-selected");
+          h.innerHTML = target.innerHTML;
+          y = target.parentNode.getElementsByClassName("same-as-selected");
           for (k = 0; k < y.length; k++) {
             y[k].removeAttribute("class");
           }
-          _this.setAttribute("class", "same-as-selected");
+          target.setAttribute("class", "same-as-selected");
           break;
 
         } else {
@@ -976,12 +977,14 @@ let listener = function(event, callback = () => {}) {
           //categoriesTable.setData(tableData[i].categoryDisplay);
 
           s.selectedIndex = i;
-          h.innerHTML = _this.innerHTML;
-          y = _this.parentNode.getElementsByClassName("same-as-selected");
+          h.innerHTML = target.innerHTML;
+          y = target.parentNode.getElementsByClassName("same-as-selected");
           for (k = 0; k < y.length; k++) {
             y[k].removeAttribute("class");
           }
-          _this.setAttribute("class", "same-as-selected");
+          target.setAttribute("class", "same-as-selected");
+
+          callback();
           break;
         }
       }

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1121,7 +1121,7 @@ let tableData_option_onclick = function() {
   period_names = {black:[], silver:[]};
 
   // Hide Reports tab for imported data
-  if (currentTableData.imported) {
+  if (currentTableData.imported || currentTableData.type === "imported") {
     $("#reports_open").hide();
   }
   else {
@@ -1467,7 +1467,10 @@ let isAccessible = function(term, includedTerms) {
   // for more data, so any terms not included in the import
   // are inaccessible
   if (
-    currentTableData.imported &&
+    (
+      currentTableData.imported || /* backwards compatibility */
+      currentTableData.type === "imported"
+    ) &&
     (
       (includedTerms && !includedTerms[term]) ||
       !currentTableData.terms[term].classes

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1151,56 +1151,56 @@ let tableData_option_onclick = function() {
     }
   }
 
-  if (currentTableData.type === "previous") {
-    // Switch to Q1
-    // (because there is no "current quarter" in the previous year)
-    listener({ target: document.getElementById("q1") }, () => {
-      // Re-initialize the quarter dropdown with the data from
-      // currentTableData
-      // (this needs to be done *after* the data have been loaded)
-      initialize_quarter_dropdown();
-      setup_quarter_dropdown();
-    });
-    document.getElementsByClassName("gpa_select-selected")[0].click();
+  // Get the term that we want to select (the currently selected term might no
+  // longer exist due to switching currentTableData)
+  let selTerm = "current";
+  switch (currentTableData.type) {
+    case "current":
+      // Assume that the current quarter of the current year has already been
+      // loaded (because we are coming back to the current year from another
+      // year)
+      selTerm = "current";
+      break;
+    case "previous":
+      // Q1 must be available; there is no "current quarter" in the previous
+      // year
+      selTerm = "q1";
+      break;
+    case "imported":
+      // Get the first term included in the imported data
+      for (term of termConverter) {
+        if (currentTableData.terms[term] && currentTableData.terms[term].GPA) {
+          selTerm = term;
+          break;
+        }
+      }
+      break;
+    default:
+      console.error(`Invalid currentTableData type ${currentTableData.type}`);
+  }
+  // Switch to this term
+  listener({ target: document.getElementById(selTerm) }, () => {
+    // Re-initialize the quarter dropdown with the data from
+    // currentTableData
+    // (this needs to be done *after* the data have been loaded, in the case
+    // that the data have not yet been loaded)
+    initialize_quarter_dropdown();
+    setup_quarter_dropdown();
+  });
 
+  if (currentTableData.type === "previous") {
     // Transfer schedule and reports from current year to previous year
     if (!currentTableData.schedule)
       currentTableData.schedule = tableData[0].schedule;
     if (!currentTableData.pdf_files)
       currentTableData.pdf_files = tableData[0].pdf_files;
   } else if (currentTableData.type === "current") {
-    // Switch to current quarter
-    // (we can assume that it is already loaded for the current year)
-    listener({ target: document.getElementById("current") }, () => {
-      // Re-initialize the quarter dropdown with the data from
-      // currentTableData
-      initialize_quarter_dropdown();
-      setup_quarter_dropdown();
-    });
-
     // Transfer schedule and reports from previous year to current year
     // (if they were first loaded while on previous year)
     if (!currentTableData.schedule)
       currentTableData.schedule = tableData[1].schedule;
     if (!currentTableData.pdf_files)
       currentTableData.pdf_files = tableData[1].pdf_files;
-  } else {
-    // Get the first term included in the imported data
-    let firstTerm = "current";
-    for (term of termConverter) {
-      if (currentTableData.terms[term] && currentTableData.terms[term].GPA) {
-        firstTerm = term;
-        break;
-      }
-    }
-
-    // Switch to this term
-    listener({ target: document.getElementById(firstTerm) }, () => {
-      // Re-initialize the quarter dropdown with the data from
-      // currentTableData
-      initialize_quarter_dropdown();
-      setup_quarter_dropdown();
-    });
   }
 
   // Keep Schedule tab in sync

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -897,7 +897,10 @@ let listener = function({ target }, callback = () => {}) {
     s = target.parentNode.parentNode.getElementsByTagName("select")[0];
     h = target.parentNode.previousSibling;
     for (i = 0; i < s.length; i++) {
-      if (s.options[i].innerHTML === target.innerHTML) {
+      // Make sure to get just the option text, without any tooltips or
+      // tooltip text
+      if (s.options[i].childNodes[0].nodeValue
+          === target.childNodes[0].nodeValue) {
         if (i === 0) {
           currentTerm = termConverter[i];
         } else {

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1093,35 +1093,38 @@ let initialize_quarter_dropdown = function(includedTerms) {
 
 let setup_quarter_dropdown = function() {
   // Set up "current quarter" entry
-  if (currentTableData.type === "previous") {
+  if (!isNaN(currentTableData.terms.current.GPA.percent)) {
     document.querySelector("#current").textContent
-      = document.querySelector("#gpa_select").options[0].textContent
-      = document.querySelector("#gpa_select").options[1].textContent
-      = "Current Quarter";
+      = document.querySelector("#init_gpa").textContent
+      = document.querySelector("#current_gpa").textContent
+      = "Current Quarter GPA: " + currentTableData.currentTermData.GPA.percent;
   } else {
     document.querySelector("#current").textContent
-      = document.querySelector("#gpa_select").options[0].textContent
-      = document.querySelector("#gpa_select").options[1].textContent
-      = "Current Quarter GPA: " + currentTableData.currentTermData.GPA.percent;
+      = document.querySelector("#init_gpa").textContent
+      = document.querySelector("#current_gpa").textContent
+      = "Current Quarter GPA: None";
   }
 
-  $(".gpa_select-items").children().each(function(i, elem) {
-    // Don't try to get quarter data for the 5th element in the list because
-    // that's not a quarter...
-    if (i === 5) return;
-    // We already set up the "current quarter"
-    if (i === 0) return;
-
-    if (!isNaN(currentTableData.terms["q" + i].GPA.percent)) {
-      document.querySelector("#gpa_select").options[i + 1].textContent
-        = this.textContent
-        = `Q${i} GPA: ${currentTableData.terms["q" + i].GPA.percent}`;
+  // Set up the four quarters
+  for (const term of termConverter) {
+    // We already set up the current quarter; this is only for Q1 to Q4
+    if (!/q\d/.test(term))
+      continue;
+    if (!isNaN(currentTableData.terms[term].GPA.percent)) {
+      document.querySelector(`#${term}`).textContent
+        = document.querySelector(`#${term}_gpa`).textContent
+        = `Q${term[1]} GPA: ${currentTableData.terms[term].GPA.percent}`;
     } else {
-      document.querySelector("#gpa_select").options[i + 1].textContent
-        = this.textContent
-        = `Q${i} GPA: None`;
+      document.querySelector(`#${term}`).textContent
+        = document.querySelector(`#${term}_gpa`).textContent
+        = `Q${term[1]} GPA: None`;
     }
-  });
+  }
+
+  // Set up cumulative GPA
+  document.querySelector("#cum").textContent
+    = document.querySelector("#cum_gpa").textContent
+    = `Cumulative GPA: ${currentTableData.cumGPA.percent}`;
 
   // Set text for currently selected quarter to be that of the corresponding
   // option

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1150,6 +1150,12 @@ let tableData_option_onclick = function() {
       setup_quarter_dropdown();
     });
     document.getElementsByClassName("gpa_select-selected")[0].click();
+
+    // Transfer schedule and reports from current year to previous year
+    if (!currentTableData.schedule)
+      currentTableData.schedule = tableData[0].schedule;
+    if (!currentTableData.pdf_files)
+      currentTableData.pdf_files = tableData[0].pdf_files;
   } else {
     classesTable.setData(currentTableData.currentTermData.classes);
     scheduleTable.setData(currentTableData.schedule.black);
@@ -1158,7 +1164,19 @@ let tableData_option_onclick = function() {
     // currentTableData
     initialize_quarter_dropdown();
     setup_quarter_dropdown();
+
+    // Transfer schedule and reports from previous year to current year
+    // (if they were first loaded while on previous year)
+    if (!currentTableData.schedule)
+      currentTableData.schedule = tableData[1].schedule;
+    if (!currentTableData.pdf_files)
+      currentTableData.pdf_files = tableData[1].pdf_files;
   }
+
+  // Keep Schedule tab in sync
+  update_formattedSchedule();
+  scheduleTable.setData(currentTableData.formattedSchedule);
+  redraw_clock();
 
   // Reset clock
   period_names = {black:[], silver:[]};

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -918,7 +918,7 @@ let listener = function(event) {
           $.ajax({
             url: "/data",
             method: "POST",
-            data: { quarter: (i - 1) },
+            data: { quarter: i - 1, year: "current" },
             dataType: "json json",
             success: responseCallbackPartial
           });
@@ -1060,21 +1060,31 @@ let setup_quarter_dropdown = function() {
   document.getElementById('gpa_select').options[1].innerHTML = "Current Quarter GPA: " + currentTableData.currentTermData.GPA.percent;
 
   $(".gpa_select-items").children().each(function(i, elem) {
-      if (i < 5) {//Don't try to get quarter data for the 5th element in the list because that's not a quarter...
-          if (i === 0) {
-              $(this).html("Current Quarter GPA: " + currentTableData.terms["current"].GPA.percent);
-              document.getElementById('gpa_select').options[0].innerHTML = "Current Quarter GPA: " + currentTableData.terms["current"].GPA.percent;
-              document.getElementById('gpa_select').options[1].innerHTML = "Current Quarter GPA: " + currentTableData.terms["current"].GPA.percent;
-          } else {
-              if (!isNaN(currentTableData.terms["q" + i].GPA.percent)) {
-                  $(this).html("Q" + i + " GPA: " + currentTableData.terms["q" + i].GPA.percent);
-                  document.getElementById('gpa_select').options[i + 1].innerHTML ="Q" + i + " GPA: " + currentTableData.terms["q" + i].GPA.percent;
-              } else {
-                  $(this).append("Q" + i + " GPA: None");
-                  document.getElementById('gpa_select').options[i + 1].innerHTML ="Q" + i + " GPA: None";
-              }
-          }
-      }
+    // Don't try to get quarter data for the 5th element in the list because
+    // that's not a quarter...
+    if (i === 5) return;
+    if (i === 0) {
+      this.textContent = `Current Quarter GPA: ${
+        currentTableData.terms["current"].GPA.percent
+      }`;
+      document.getElementById('gpa_select').options[0].textContent
+        = document.getElementById('gpa_select').options[1].textContent
+        = `Current Quarter GPA: ${
+          currentTableData.terms["current"].GPA.percent
+        }`;
+    } else if (!isNaN(currentTableData.terms["q" + i].GPA.percent)) {
+      this.textContent = `Q${i} GPA: ${
+        currentTableData.terms["q" + i].GPA.percent
+      }`;
+      document.getElementById('gpa_select').options[i + 1].textContent
+        = `Q${i} GPA: ${
+          currentTableData.terms["q" + i].GPA.percent
+        }`;
+    } else {
+      this.textContent = `Q${i} GPA: None`;
+      document.getElementById('gpa_select').options[i + 1].textContent
+        = `Q${i} GPA: None`;
+    }
   });
 };
 

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1046,8 +1046,16 @@ let initialize_quarter_dropdown = function(includedTerms) {
       c.innerHTML = selElmnt.options[j].innerHTML;
       c.id = termConverter[j - 1] || "cum";
     }
-    const term = termConverter[parseInt(c.id[1]) || 0];
-    const isAccessibleObj = isAccessible(term, includedTerms);
+
+    let accessible, reason;
+    if (c.id === "cum") {
+      accessible = true;
+      reason = "";
+    } else {
+      const term = termConverter[parseInt(c.id[1]) || 0];
+      ({ accessible, reason } = isAccessible(term, includedTerms));
+    }
+
     $(c)
       .removeClass("inaccessible")
       .remove(".tooltiptext")
@@ -1055,15 +1063,13 @@ let initialize_quarter_dropdown = function(includedTerms) {
       .removeAttr("tabindex");
     c.removeEventListener("click", listener);
 
-    if (isAccessibleObj.accessible) {
+    if (accessible) {
       c.addEventListener("click", listener);
-    }
-    else {
+    } else {
       $(c)
         .addClass("inaccessible")
-        .attr("tooltip", isAccessibleObj.reason)
+        .attr("tooltip", reason)
         .attr("tabindex", 0);
-
       setup_tooltips();
     }
 

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -1168,14 +1168,15 @@ let tableData_option_onclick = function() {
       currentTableData.schedule = tableData[0].schedule;
     if (!currentTableData.pdf_files)
       currentTableData.pdf_files = tableData[0].pdf_files;
-  } else {
-    classesTable.setData(currentTableData.currentTermData.classes);
-    scheduleTable.setData(currentTableData.schedule.black);
-
-    // Re-initialize the quarter dropdown with the data from
-    // currentTableData
-    initialize_quarter_dropdown();
-    setup_quarter_dropdown();
+  } else if (currentTableData.type === "current") {
+    // Switch to current quarter
+    // (we can assume that it is already loaded for the current year)
+    listener({ target: document.getElementById("current") }, () => {
+      // Re-initialize the quarter dropdown with the data from
+      // currentTableData
+      initialize_quarter_dropdown();
+      setup_quarter_dropdown();
+    });
 
     // Transfer schedule and reports from previous year to current year
     // (if they were first loaded while on previous year)
@@ -1183,6 +1184,23 @@ let tableData_option_onclick = function() {
       currentTableData.schedule = tableData[1].schedule;
     if (!currentTableData.pdf_files)
       currentTableData.pdf_files = tableData[1].pdf_files;
+  } else {
+    // Get the first term included in the imported data
+    let firstTerm = "current";
+    for (term of termConverter) {
+      if (currentTableData.terms[term] && currentTableData.terms[term].GPA) {
+        firstTerm = term;
+        break;
+      }
+    }
+
+    // Switch to this term
+    listener({ target: document.getElementById(firstTerm) }, () => {
+      // Re-initialize the quarter dropdown with the data from
+      // currentTableData
+      initialize_quarter_dropdown();
+      setup_quarter_dropdown();
+    });
   }
 
   // Keep Schedule tab in sync

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1047,7 +1047,8 @@ function responseCallbackPartial(response) {
     currentTableData.terms[currentTerm].calcGPA = temp_term_data.calcGPA;
     currentTableData.terms[currentTerm].quarter_oid = temp_term_data.quarter_oid;
 
-    currentTableData.overview = response.overview;
+    if (!currentTableData.overview)
+        currentTableData.overview = response.overview;
     currentTableData.cumGPA =
         response.cumGPA || cumGPA(currentTableData.overview);
     if (currentTableData.cumGPA.percent == NaN) {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -29,7 +29,10 @@ let currentTerm = "current";
  *  @property {"current" | "previous" | "imported"} [type]
  */
 /** @type {TableDataObject[]}*/
-let tableData = [{ name: "Current Year", type: "current" }];
+let tableData = [
+    { name: "Current Year", type: "current" },
+    { name: "Previous Year", type: "previous" },
+];
 let currentTableDataIndex = 0;
 /**@type {TableDataObject}*/
 let currentTableData = tableData[currentTableDataIndex];
@@ -1308,7 +1311,7 @@ $("#import_button").click(async () => {
 $.ajax({
     url: "/data",
     method: "POST",
-    data: { quarter: 0 },
+    data: { quarter: 0, year: "current" },
     dataType: "json json",
 }).then(responseCallback);
 //#endif

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1118,7 +1118,7 @@ function scheduleCallback(response) {
         }
     }
 
-    update_formattedSchedule(new Date().getDay());
+    update_formattedSchedule();
     scheduleTable.setData(currentTableData.formattedSchedule);
     redraw_clock();
 }

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -429,6 +429,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                             .classes[selected_class_i].oid,
                         quarter_id: currentTableData.currentTermData
                             .quarter_oid,
+                        year: currentTableData.type,
                     },
                 });
                 if ([high, low, median, mean].some(x => x === undefined)) {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -988,17 +988,18 @@ function responseCallback(response, includedTerms) {
         computeGPA(currentTableData.terms.current.classes);
 
     currentTableData.overview = response.overview;
-
-    currentTableData.cumGPA = response.cumGPA || cumGPA(currentTableData.overview);
-
+    currentTableData.cumGPA =
+        response.cumGPA || cumGPA(currentTableData.overview);
     if (currentTableData.cumGPA.percent == NaN) {
         currentTableData.cumGPA.percent = "";
     }
-    document.getElementById("cum_gpa").innerHTML = "Cumulative GPA: " + currentTableData.cumGPA.percent.toFixed(2);
+    document.getElementById("cum_gpa").innerHTML =
+        "Cumulative GPA: " + currentTableData.cumGPA.percent.toFixed(2);
 
     // Calculate GPA for each quarter
     for (let i = 1; i <= 4; i++) {
-        currentTableData.terms["q" + i].GPA = computeGPAQuarter(currentTableData.overview, i);
+        currentTableData.terms["q" + i].GPA =
+            computeGPAQuarter(currentTableData.overview, i);
     }
 
     //Stuff to do now that tableData is initialized
@@ -1044,6 +1045,21 @@ function responseCallbackPartial(response) {
     currentTableData.terms[currentTerm].GPA = temp_term_data.GPA;
     currentTableData.terms[currentTerm].calcGPA = temp_term_data.calcGPA;
     currentTableData.terms[currentTerm].quarter_oid = temp_term_data.quarter_oid;
+
+    currentTableData.overview = response.overview;
+    currentTableData.cumGPA =
+        response.cumGPA || cumGPA(currentTableData.overview);
+    if (currentTableData.cumGPA.percent == NaN) {
+        currentTableData.cumGPA.percent = "";
+    }
+    document.getElementById("cum_gpa").innerHTML =
+        "Cumulative GPA: " + currentTableData.cumGPA.percent.toFixed(2);
+
+    // Calculate GPA for each quarter
+    for (let i = 1; i <= 4; i++) {
+        currentTableData.terms["q" + i].GPA =
+            computeGPAQuarter(currentTableData.overview, i);
+    }
 
     /*
     if (currentTerm === 'current') {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -26,10 +26,10 @@ let currentTerm = "current";
  *	@property {Schedule} [schedule]
  *	@property {Terms} [terms]
  *  @property {?string} [username]
- *  @property {boolean} [imported=true]
+ *  @property {"current" | "previous" | "imported"} [type]
  */
 /** @type {TableDataObject[]}*/
-let tableData = [{ name: "Current Year" }];
+let tableData = [{ name: "Current Year", type: "current" }];
 let currentTableDataIndex = 0;
 /**@type {TableDataObject}*/
 let currentTableData = tableData[currentTableDataIndex];

--- a/serve.js
+++ b/serve.js
@@ -162,7 +162,7 @@ app.post('/data', async (req, res) => {
         try {
             res.send(await scraper.get_student(
                 req.session.username, req.session.password,
-                parseInt(req.body.quarter)
+                parseInt(req.body.quarter), req.body.year
             ));
         } catch (e) {
             console.error(e);

--- a/serve.js
+++ b/serve.js
@@ -131,12 +131,12 @@ app.use(session({
 }));
 
 app.post('/stats', async (req, res) => {
-    console.log(`\n\nNEW STATS REQUEST: ${req.body.assignment_id}, ${req.body.class_id}, ${req.body.quarter_id} \n------------------`);
+    console.log(`\n\nNEW STATS REQUEST: ${req.body.assignment_id}, ${req.body.class_id}, ${req.body.quarter_id}, ${req.body.year} \n------------------`);
 
     try {
         res.send(await scraper.get_stats(
             req.session.username, req.session.password, req.body.assignment_id,
-            req.body.class_id, req.body.quarter_id
+            req.body.class_id, req.body.quarter_id, req.body.year
         ));
     } catch (e) {
         console.error(e);

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -8,7 +8,6 @@ import type {
   ClassInfo,
   ClassDetails,
   Category,
-  TermSpec,
 } from "./types";
 
 import type {
@@ -23,6 +22,7 @@ import type {
   AttendanceEvent,
   ActivityEvent,
   Stats,
+  TermSpec,
 } from "./types-shared";
 
 // Using `import type` with an enum disallows accessing the enum variants
@@ -59,7 +59,7 @@ export async function get_student(
       // For previous-year data, every class is listed under every quarter, so
       // we need to do an additional check using the "term" attribute
       if (year !== Year.Current && !await match_termspec(
-        session, details.term as TermSpec, quarter, year
+        session, details.term, quarter, year
       )) {
         return undefined;
       }

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -191,7 +191,7 @@ export async function get_schedule(
 
 export async function get_stats(
   username: string, password: string, assignment_id: string, class_id: string,
-  quarter_id: string
+  quarter_id: string, year: Year
 ): Promise<Stats | {}> {
   return await get_session(username, password, async ({ session_id }) => {
     // The REST API does not expose assignment statistics (as far as we know),
@@ -224,6 +224,7 @@ export async function get_stats(
         "org.apache.struts.taglib.html.TOKEN": apache_token,
         "userEvent": "950",
         "termFilter": quarter_id,
+        "yearFilter": year,
       }),
     });
 

--- a/src/types-shared.ts
+++ b/src/types-shared.ts
@@ -31,7 +31,7 @@ export interface Assignment {
 export interface OverviewItem {
   class: string;
   teacher: string;
-  term: string;
+  term: TermSpec;
   q1: string;
   q2: string;
   q3: string;
@@ -102,3 +102,7 @@ export enum Year {
   Current = "current",
   Previous = "previous",
 }
+
+// TODO support week specifiers (W1 to W14) which may be used for RSTA
+// Exploratory; use Aspen schedule to find mapping
+export type TermSpec = "FY" | "S1" | "S2" | "Q1" | "Q2" | "Q3" | "Q4";

--- a/src/types-shared.ts
+++ b/src/types-shared.ts
@@ -97,3 +97,8 @@ export enum Quarter {
   Q3,
   Q4,
 }
+
+export enum Year {
+  Current = "current",
+  Previous = "previous",
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Quarter } from "./types-shared";
+import { Quarter, TermSpec } from "./types-shared";
 
 export interface Session {
   session_id: string;
@@ -14,7 +14,7 @@ export interface ClassInfo {
   name: string;
   grades: Map<Quarter, string>;
   teacher: string;
-  term: string;
+  term: TermSpec;
   oid: string;
 }
 
@@ -32,10 +32,6 @@ export interface Category {
   weight: number;
   oid: string;
 }
-
-// TODO support week specifiers (W1 to W14) which may be used for RSTA
-// Exploratory; use Aspen schedule to find mapping
-export type TermSpec = "FY" | "S1" | "S2" | "Q1" | "Q2" | "Q3" | "Q4";
 
 export enum AspineErrorCode {
   LOGINFAIL = "loginfail",

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export interface Category {
   oid: string;
 }
 
+// TODO support week specifiers (W1 to W14) which may be used for RSTA
+// Exploratory; use Aspen schedule to find mapping
+export type TermSpec = "FY" | "S1" | "S2" | "Q1" | "Q2" | "Q3" | "Q4";
+
 export enum AspineErrorCode {
   LOGINFAIL = "loginfail",
   ASPENDOWN = "aspendown",


### PR DESCRIPTION
Closes #99. Thanks to the REST API, the backend implementation here is much simpler than that in #182. While fetching grades  seems to work, I am marking this pull request as a draft because there are a few known bugs:
- [x] Assignment statistics do not work for previous-year classes
- [x] Switching between current year and previous year seems to cause some buggy behavior in the term dropdown:
![image](https://user-images.githubusercontent.com/45520974/113487772-ee091300-9487-11eb-8449-315b1f308768.png)
- [x] The schedule and reports callbacks send data to `currentTableData`, which may be current or previous, meaning that the other option will not have schedule/reports data; the callbacks should be updated to send their data to both `tableData[0]` and `tableData[1]`.
- [x] Switching between years may cause the quarter displayed in the quarter/GPA dropdown to be inconsistent with the quarter whose grades are displayed. This is because, when switching years (except when switching to "previous year"), Aspine tries to look up the same quarter in the other year, which may not exist; in this case, the dropdown displays the nonexistent quarter and the table displays something else.