### PR TITLE
Redesign tables on mobile

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -839,7 +839,8 @@ canvas#large_clock {
   width: 250px
 }
 
-#stats_modal_table {
+#stats_modal_table, 
+#no_stats_modal_table {
   font-family: sans-serif;
   border-collapse: collapse;
   width: 100%;
@@ -847,14 +848,17 @@ canvas#large_clock {
 }
 
 #stats_modal_table td,
-#stats_modal_table th {
+#stats_modal_table th,
+#no_stats_modal_table td,
+#no_stats_modal_table th {
   border: 1px solid var(--white3);
   text-align: left;
   padding: 8px;
   color: var(--black);
 }
 
-#stats_modal_table th {
+#stats_modal_table th,
+#no_stats_modal_table th {
   min-width: 30%;
   max-width: 50%;
 }

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -800,6 +800,7 @@ canvas#large_clock {
 }
 
 #stats_modal_content {
+  min-height: 5rem;
   margin: auto;
   top: 40px;
   -webkit-animation-name: statsanimatetop !important;

--- a/public/home.html
+++ b/public/home.html
@@ -139,8 +139,27 @@
     <div id="stats_modal_content" class="modal-content">
       <span class="close" onclick="hideModal('stats')">&times;</span>
       <div id="there_are_no_stats">
-        <p id="no_stats_caption">No Statistics information for this assignment.</p>
+        <h3 id="no_stats_modal_title">Assignment: </h3>
+        <table id="no_stats_modal_table">
+          <tr>
+            <th>Your Score</th>
+            <td id="no_stats_modal_score"></td>
+          </tr>
+          <tr>
+            <th>Date Assigned</th>
+            <td id="no_stats_modal_date_assigned"></td>
+          </tr>
+          <tr>
+            <th>Date Due</th>
+            <td id="no_stats_modal_date_due"></td>
+          </tr>
+          <tr>
+            <th>Assignment Feedback</th>
+            <td id="no_stats_modal_feedback"></td>
+          </tr>
+        </table><br>
       </div>
+      <p id="no_stats_caption">No Statistics information for this assignment.</p>
       <div id="there_are_stats">
         <h3 id="stats_modal_title">Modal Title..</h3>
         <div id="notgraph">

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -445,7 +445,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                     $("#no_stats_modal_feedback").text(assignment_feedback || "None");
                     $("#there_are_no_stats").show();
                     document.getElementById("no_stats_caption").innerHTML = "";
-                    document.getElementById("stats_modal_content").style.height = "15rem";
+                    document.getElementById("stats_modal_content").style.height = "20rem";
                     return;
                 }
 
@@ -460,7 +460,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                 $("#stats_modal_date_due").text(date_due);
                 $("#stats_modal_feedback").text(assignment_feedback || "None");
 
-                $("#stats_modal_content").css("height", "450px");
+                $("#stats_modal_content").css("height", "550px");
                 $("#there_are_stats").show();
                 $("#there_are_no_stats").hide();
                 $("#no_stats_caption").hide();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -445,7 +445,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                     $("#no_stats_modal_feedback").text(assignment_feedback || "None");
                     $("#there_are_no_stats").show();
                     document.getElementById("no_stats_caption").innerHTML = "";
-                    document.getElementById("stats_modal_content").style.height = "20rem";
+                    document.getElementById("stats_modal_content").style.height = "auto";
                     return;
                 }
 
@@ -460,7 +460,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                 $("#stats_modal_date_due").text(date_due);
                 $("#stats_modal_feedback").text(assignment_feedback || "None");
 
-                $("#stats_modal_content").css("height", "550px");
+                $("#stats_modal_content").css("height", "auto");
                 $("#there_are_stats").show();
                 $("#there_are_no_stats").hide();
                 $("#no_stats_caption").hide();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -368,6 +368,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
             field: "percentage",
             formatter: rowGradeFormatter,
             headerSort: false,
+            width: window.matchMedia("(max-width: 576px)").matches ? 120 : "",
         },
         {
             title: "Corrections",
@@ -676,6 +677,12 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
         },
     ],
 });
+
+if (window.matchMedia("(max-width: 576px)").matches) {
+    assignmentsTable.deleteColumn("category");
+    assignmentsTable.deleteColumn("score");
+    assignmentsTable.deleteColumn("max_score");
+}
 
 //create Tabulator on DOM element with id "scheduleTable"
 let scheduleTable = new Tabulator("#scheduleTable", {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -407,7 +407,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                         .assignments[cell.getRow().getPosition()].synthetic
                 ) return;
                 noStats();
-                document.getElementById("no_stats_caption").innerHTML = "Loading Statistics...";
+                document.getElementById("no_stats_caption").innerHTML = "Loading Assignment Info...";
                 showModal("stats");
 
                 const {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -751,6 +751,7 @@ let classesTable = new Tabulator("#classesTable", {
             align: "left",
             formatter: gradeFormatter,
             headerSort: false,
+            width: window.matchMedia("(max-width: 576px)").matches ? 100 : "",
         },
         {
             title: "Export Table Data",

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -139,7 +139,6 @@ let noStats = function() {
     $("#there_are_no_stats").hide();
     $("#no_stats_caption").show();
     document.getElementById("no_stats_caption").innerHTML = "No Statistics Data for this assignment";
-    document.getElementById("stats_modal_content").style.height = "5rem";
 };
 
 /**
@@ -445,7 +444,6 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                     $("#no_stats_modal_feedback").text(assignment_feedback || "None");
                     $("#there_are_no_stats").show();
                     document.getElementById("no_stats_caption").innerHTML = "";
-                    document.getElementById("stats_modal_content").style.height = "auto";
                     return;
                 }
 
@@ -460,7 +458,6 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                 $("#stats_modal_date_due").text(date_due);
                 $("#stats_modal_feedback").text(assignment_feedback || "None");
 
-                $("#stats_modal_content").css("height", "auto");
                 $("#there_are_stats").show();
                 $("#there_are_no_stats").hide();
                 $("#no_stats_caption").hide();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -397,7 +397,7 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                     .assignments.filter(value =>
                         !value["placeholder"]
                     )[cell.getRow().getPosition()].synthetic
-            ) ? "" : '<i class="fa fa-info standard-icon tooltip" aria-hidden="true" tooltip="Statistics"></i>',
+            ) ? "" : '<i class="fa fa-info standard-icon tooltip" aria-hidden="true" tooltip="Info"></i>',
             width: 40,
             align: "center",
             cellClick: async function(e, cell) {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -136,7 +136,8 @@ window.addEventListener('resize', function() {
 */
 let noStats = function() {
     $("#there_are_stats").hide();
-    $("#there_are_no_stats").show();
+    $("#there_are_no_stats").hide();
+    $("#no_stats_caption").show();
     document.getElementById("no_stats_caption").innerHTML = "No Statistics Data for this assignment";
     document.getElementById("stats_modal_content").style.height = "5rem";
 };
@@ -436,7 +437,14 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                     }
                 )).json();
                 if ([high, low, median, mean].some(x => x === undefined)) {
-                    noStats();
+                    $("#no_stats_modal_title").text(`Assignment: ${assignment}`);
+                    $("#no_stats_modal_score").text(`${score} / ${max_score}`);
+                    $("#no_stats_modal_date_assigned").text(date_assigned);
+                    $("#no_stats_modal_date_due").text(date_due);
+                    $("#no_stats_modal_feedback").text(assignment_feedback || "None");
+                    $("#there_are_no_stats").show();
+                    document.getElementById("no_stats_caption").innerHTML = "";
+                    document.getElementById("stats_modal_content").style.height = "15rem";
                     return;
                 }
 
@@ -451,9 +459,10 @@ let assignmentsTable = new Tabulator("#assignmentsTable", {
                 $("#stats_modal_date_due").text(date_due);
                 $("#stats_modal_feedback").text(assignment_feedback || "None");
 
-                $("#stats_modal_content").css("height", "600px");
+                $("#stats_modal_content").css("height", "450px");
                 $("#there_are_stats").show();
                 $("#there_are_no_stats").hide();
+                $("#no_stats_caption").hide();
 
                 let plotStats = {};
                 plotStats.fiveNums = [low, q1, median, q3, high];


### PR DESCRIPTION
Create a table for assignments without stats that shows your score, the
maximum score, date assigned, date due, and assignment feedback.
For now, I'm trying to get more data to show up in the modal to remove
table columns on mobile, but eventually, the info in the modal will be
transferred to a separate region under the row in the table.