### PR TITLE
Switch from jQuery AJAX to Fetch

### DIFF
--- a/public/js/buttonFunctions.js
+++ b/public/js/buttonFunctions.js
@@ -315,18 +315,7 @@ let exportTableData = async function(prefs) {
 
   let obj = {};
 
-//#ifndef lite
-  obj.version = await $.ajax("/version");
-//#endif
-
-//#ifdef lite
-/*
-  obj.version = (
-//#include VERSION
-  );
-*/
-//#endif
-
+  obj.version = document.querySelector("#version").textContent;
   obj.username = currentTableData.username;
   obj.overview = currentTableData.overview;
 
@@ -349,15 +338,16 @@ let exportTableData = async function(prefs) {
             $("#export_status").html(
               `Downloading quarter "${term}" from Aspen&hellip;`
             );
-            const response = await $.ajax({
-              url: "/data",
+            const response = await (await fetch("/data", {
               method: "POST",
-              data: {
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
                 quarter: parseInt(term.match(/\d+/)[0]),
                 year: "current",
-              },
-              dataType: "json json"
-            });
+              }),
+            })).json();
             currentTerm = term;
             responseCallbackPartial(response);
             $("#export_status").html("");
@@ -407,18 +397,7 @@ let exportTableData = async function(prefs) {
  * @returns {Promise<string>}
  */
 let importTableData = async function(obj) {
-
-//#ifndef lite
-  let version = await $.ajax("/version");
-//#endif
-
-//#ifdef lite
-/*
-  let version = (
-//#include VERSION
-  );
-*/
-//#endif
+  const version = document.querySelector("#version").textContent;
 
   let _ov, _v;
   if (

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -107,10 +107,7 @@ function update_formattedSchedule() {
 }
 
 //#ifndef lite
-$.ajax({
-    url: "schedule.json",
-    method: "GET"
-}).then(schedulesCallback);
+fetch("/schedule.json").then(async res => schedulesCallback(await res.json()));
 //#endif
 //#ifdef lite
 /*

--- a/public/js/extraFunctions.js
+++ b/public/js/extraFunctions.js
@@ -205,15 +205,15 @@ let listener = function({ target }, callback = () => {}) {
           term_dropdown_active = false;
 
           const year = currentTableDataIndex === 0 ? "current" : "previous";
-          $.ajax({
-            url: "/data",
+          fetch("/data", {
             method: "POST",
-            data: { quarter: i - 1, year: year },
-            dataType: "json json",
-            success: response => {
-              responseCallbackPartial(response);
-              callback();
+            headers: {
+              "Content-Type": "application/json",
             },
+            body: JSON.stringify({ quarter: i - 1, year: year }),
+          }).then(async res => {
+            responseCallbackPartial(await res.json());
+            callback();
           });
 
           $("#loader").show();


### PR DESCRIPTION
Migrate from jQuery's [`$.ajax`](https://api.jquery.com/Jquery.ajax/) to the standard [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).

Also, prevent a race condition between the version callback and the updates (changelog) callback.