### PR TITLE
Add support for fall 2021 schedule

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -940,7 +940,7 @@ p#large_clock_period {
 }
 #lunch_range {
   -webkit-appearance: none;
-  width: 100px;
+  width: 157.5px;
   height: 34px;
   border-radius: 17px;
   background: var(--gray3-to-white);
@@ -988,9 +988,9 @@ p#large_clock_period {
   top: -44px;
   height: 0px;
   pointer-events: none;
-  letter-spacing: 2em;
+  letter-spacing: 1.75em;
   text-align: center;
-  left: 25px;
+  left: 22px;
 }
 
 .unselectable {

--- a/public/home.html
+++ b/public/home.html
@@ -304,7 +304,7 @@
         <p id="lunch_label" class="unselectable">ABC</p>
       </div>
       <div style="margin-left: auto; align-self: center;">
-        <a href="https://drive.google.com/file/d/1KY24FxyA_g_t3CGIeAzFD14g2t5I8HG5/view" target="_blank">More information about schedules in May/June 2021</a>
+        <a href="https://drive.google.com/file/d/12Xbk-tNsQvIsS5_Ty4eVJPHRQAow6tjI/view" target="_blank">CRLS Bell Schedule 2021-2022</a>
       </div>
     </div>
     <div id="scheduleTable"></div>

--- a/public/home.html
+++ b/public/home.html
@@ -300,8 +300,8 @@
       </div>
       <div>
         <p>Lunch:</p>
-        <input type="range" min="0" max="1" value="0" id="lunch_range" onchange="update_lunch()" class="unselectable">
-        <p id="lunch_label" class="unselectable">AB</p>
+        <input type="range" min="0" max="2" value="0" id="lunch_range" onchange="update_lunch()" class="unselectable">
+        <p id="lunch_label" class="unselectable">ABC</p>
       </div>
       <div style="margin-left: auto; align-self: center;">
         <a href="https://drive.google.com/file/d/1KY24FxyA_g_t3CGIeAzFD14g2t5I8HG5/view" target="_blank">More information about schedules in May/June 2021</a>

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -215,11 +215,11 @@ function get_lunch(p3room, p3id) {
     if (floor <= 2) {
         return "a";
     }
-    // Rindge building floors 3, 4, 5 are lunch B if science, lunch C otherwise
-    if (p3id.startswith("S")) {
-        return "b";
-    } else {
+    // Rindge building floors 3, 4, 5 are lunch C if science, lunch B otherwise
+    if (p3id.startsWith("S")) {
         return "c";
+    } else {
+        return "b";
     }
 }
 

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -17,7 +17,7 @@ logo = document.getElementById("logo");
 
 // Controls whether to use the covid-19 schedule or the regular schedule
 const covid_schedule = true;
-let current_schedule = covid_schedule ? "covid-may" : "regular";
+let current_schedule = covid_schedule ? "2021fa" : "regular";
 // For covid-19 schedule
 let selected_day_of_week = -1;
 let day_of_week;
@@ -193,6 +193,7 @@ function update_lunch() {
 
 // Takes an object with "room" and "id"
 function get_lunch(p3room, p3id) {
+    // TODO update this function for fall 2021
     // RSTA auto garage is lunch A
     if (p3room === "GAR") {
         return "a";
@@ -263,9 +264,9 @@ function get_period_name(default_name, day_of_week) {
 
         // Determine which covid schedule to use
         if (day_of_week === 3) {
-            current_schedule = `covid-may-w${suffix || ""}`;
+            current_schedule = `2021fa-w${suffix || ""}`;
         } else {
-            current_schedule = `covid-may${suffix || ""}`;
+            current_schedule = `2021fa${suffix || ""}`;
         }
     } else {
         bs_day = document.getElementById("schedule_title").innerHTML

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -193,26 +193,33 @@ function update_lunch() {
 
 // Takes an object with "room" and "id"
 function get_lunch(p3room, p3id) {
-    // TODO update this function for fall 2021
     // RSTA auto garage is lunch A
     if (p3room === "GAR") {
         return "a";
     }
 
-    // War Memorial and remote teachers are lunch B
+    // War Memorial is lunch C
     if (isNaN(parseInt(p3room))) {
-        return "b";
+        return "c";
     }
 
     const floor = parseInt(p3room[0]);
     const zone = parseInt(p3room[1]);
 
-    if (floor <= 4 && zone < 6) {
-        // Rindge building floors 0 to 4
+    // Arts building is lunch C
+    if (zone == 6) {
+        return "c";
+    }
+
+    // Rindge building floors 1 and 2 are lunch A
+    if (floor <= 2) {
         return "a";
-    } else {
-        // Rindge building floor 5 and arts building
+    }
+    // Rindge building floors 3, 4, 5 are lunch B if science, lunch C otherwise
+    if (p3id.startswith("S")) {
         return "b";
+    } else {
+        return "c";
     }
 }
 
@@ -244,7 +251,7 @@ function get_period_name(default_name, day_of_week) {
 
                 // Update slider
                 document.querySelector("#lunch_range").value =
-                    ["a", "b"].indexOf(lunch);
+                    ["a", "b", "c"].indexOf(lunch);
 
                 break;
             }

--- a/public/schedule.toml
+++ b/public/schedule.toml
@@ -322,7 +322,7 @@ end = 15:00:00.001
 # }}}
 
 # Covid-19 schedule (May/June 2021) {{{
-# In effect since May 10, 2021
+# In effect from May 10 to June 14, 2021
 
 # Non-Wednesday schedule, lunch-agnostic {{{
 [[covid-may]]
@@ -584,6 +584,347 @@ end = 13:10:00.000
 name = "Advisory"
 start = 13:15:00.000
 end = 14:40:00.000
+# }}}
+
+# }}}
+
+# Fall 2021 schedule {{{
+# In effect since September 10, 2021
+
+# Non-Wednesday schedule, lunch-agnostic {{{
+[[2021fa]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2021fa]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2021fa]]
+name = "Lunch A"
+start = 11:30:00.000
+end = 12:00:00.000
+
+[[2021fa]]
+name = "Lunch B"
+start = 12:17:00.000
+end = 12:47:00.000
+
+[[2021fa]]
+name = "Lunch C"
+start = 13:00:00.000
+end = 13:30:00.000
+
+[[2021fa]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2021fa]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Non-Wednesday schedule, Lunch A {{{
+[[2021fa-a]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-a]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2021fa-a]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2021fa-a]]
+name = "Lunch A"
+start = 11:30:00.000
+end = 12:00:00.000
+
+[[2021fa-a]]
+name = "Period 3"
+start = 12:05:00.000
+end = 13:30:00.000
+
+[[2021fa-a]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2021fa-a]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Non-Wednesday schedule, Lunch B {{{
+[[2021fa-b]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-b]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2021fa-b]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2021fa-b]]
+name = "Period 3"
+start = 11:32:00.000
+end = 12:17:00.000
+
+[[2021fa-b]]
+name = "Lunch B"
+start = 12:17:00.000
+end = 12:47:00.000
+
+[[2021fa-b]]
+name = "Period 3"
+start = 12:50:00.000
+end = 13:30:00.000
+
+[[2021fa-b]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2021fa-b]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Non-Wednesday schedule, Lunch C {{{
+[[2021fa-c]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-c]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2021fa-c]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2021fa-c]]
+name = "Period 3"
+start = 11:35:00.000
+end = 13:00:00.000
+
+[[2021fa-c]]
+name = "Lunch C"
+start = 13:00:00.000
+end = 13:30:00.000
+
+[[2021fa-c]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2021fa-c]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, lunch-agnostic {{{
+[[2021fa-w]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-w]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2021fa-w]]
+name = "Community Meeting"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2021fa-w]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2021fa-w]]
+name = "Lunch A"
+start = 11:50:00.000
+end = 12:20:00.000
+
+[[2021fa-w]]
+name = "Lunch B"
+start = 12:32:00.000
+end = 13:02:00.000
+
+[[2021fa-w]]
+name = "Lunch C"
+start = 13:10:00.000
+end = 13:40:00.000
+
+[[2021fa-w]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2021fa-w]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, Lunch A {{{
+[[2021fa-w-a]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-w-a]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2021fa-w-a]]
+name = "Community Meeting"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2021fa-w-a]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2021fa-w-a]]
+name = "Lunch A"
+start = 11:50:00.000
+end = 12:20:00.000
+
+[[2021fa-w-a]]
+name = "Period 3"
+start = 12:25:00.000
+end = 13:40:00.000
+
+[[2021fa-w-a]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2021fa-w-a]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, Lunch B {{{
+[[2021fa-w-b]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-w-b]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2021fa-w-b]]
+name = "Community Meeting"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2021fa-w-b]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2021fa-w-b]]
+name = "Period 3"
+start = 11:52:00.000
+end = 12:32:00.000
+
+[[2021fa-w-b]]
+name = "Lunch B"
+start = 12:32:00.000
+end = 13:02:00.000
+
+[[2021fa-w-b]]
+name = "Period 3"
+start = 13:05:00.000
+end = 13:40:00.000
+
+[[2021fa-w-b]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2021fa-w-b]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, Lunch C {{{
+[[2021fa-w-c]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2021fa-w-c]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2021fa-w-c]]
+name = "Community Meeting"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2021fa-w-c]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2021fa-w-c]]
+name = "Period 3"
+start = 11:55:00.000
+end = 13:10:00.000
+
+[[2021fa-w-c]]
+name = "Lunch C"
+start = 13:10:00.000
+end = 13:40:00.000
+
+[[2021fa-w-c]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2021fa-w-c]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
 # }}}
 
 # }}}

--- a/public/schedule.toml
+++ b/public/schedule.toml
@@ -650,7 +650,7 @@ start = 10:05:00.000
 end = 11:30:00.000
 
 [[2021fa-a]]
-name = "Lunch A"
+name = "Lunch"
 start = 11:30:00.000
 end = 12:00:00.000
 
@@ -692,7 +692,7 @@ start = 11:32:00.000
 end = 12:17:00.000
 
 [[2021fa-b]]
-name = "Lunch B"
+name = "Lunch"
 start = 12:17:00.000
 end = 12:47:00.000
 
@@ -734,7 +734,7 @@ start = 11:35:00.000
 end = 13:00:00.000
 
 [[2021fa-c]]
-name = "Lunch C"
+name = "Lunch"
 start = 13:00:00.000
 end = 13:30:00.000
 
@@ -818,7 +818,7 @@ start = 10:35:00.000
 end = 11:50:00.000
 
 [[2021fa-w-a]]
-name = "Lunch A"
+name = "Lunch"
 start = 11:50:00.000
 end = 12:20:00.000
 
@@ -865,7 +865,7 @@ start = 11:52:00.000
 end = 12:32:00.000
 
 [[2021fa-w-b]]
-name = "Lunch B"
+name = "Lunch"
 start = 12:32:00.000
 end = 13:02:00.000
 
@@ -912,7 +912,7 @@ start = 11:55:00.000
 end = 13:10:00.000
 
 [[2021fa-w-c]]
-name = "Lunch C"
+name = "Lunch"
 start = 13:10:00.000
 end = 13:40:00.000
 

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -172,9 +172,26 @@ export async function get_schedule(
           const textarea = document.createElement("textarea");
           const [id, name, teacher, room] = lines.map(line => {
             textarea.innerHTML = line;
-            return textarea.value;
+            return textarea.value.trim();
           });
-          const aspenPeriod = periods[i];
+
+          let aspenPeriod = periods[i];
+
+          // Convert aspenPeriod from incorrect to correct period
+          // TODO remove this once Aspen reports periods correctly
+          let [num, per] = aspenPeriod.split("-");
+          let match;
+          if (per === "CM") {
+            per = "02B";
+          } else if ((match = per.match(/0\d/))) {
+            let perNum = parseInt(match[0].slice(-1));
+            if (perNum == 2 || perNum == 3) {
+              per = `0${perNum + 1}B`;
+            } else if (perNum >= 4) {
+              per = "PM";
+            }
+          }
+          aspenPeriod = `${num}-${per}`;
 
           if (name === "Study Support") {
             return undefined;


### PR DESCRIPTION
Closes #308 and adds support for the new schedule to `schedule.toml` and the frontend generally. Lunch detection has not yet been updated for the new system.

Additionally, there is a bug on Aspen which causes periods to be misaligned. We could compensate for this with some hacky code in our backend, but this will break once Aspen is fixed. So, I think the best course of action is to keep the backend code as-is and wait for Aspen to be fixed.
![image](https://user-images.githubusercontent.com/45520974/135164086-47d747f4-502b-4ed0-a12d-a0fc7784dbfc.png)
