### PR TITLE
Downgrade @iarna/toml to fix issues on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",
-        "@iarna/toml": "^3.0.0",
+        "@iarna/toml": "^2.2.5",
         "animate.css": "^4.1.1",
         "body-parser": "^1.19.0",
         "commander": "^7.2.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@iarna/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -2287,9 +2287,9 @@
       "integrity": "sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w=="
     },
     "@iarna/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3",
-    "@iarna/toml": "^3.0.0",
+    "@iarna/toml": "^2.2.5",
     "animate.css": "^4.1.1",
     "body-parser": "^1.19.0",
     "commander": "^7.2.0",


### PR DESCRIPTION
Fixes #326. Version 2.2.5, the latest stable version of `@iarna/toml`, parses Windows-style newlines just fine, so downgrade from 3.0.0 to 2.2.5.