### PR TITLE
Update Aspine for usage in SY22-23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -962,6 +963,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {

--- a/public/home.html
+++ b/public/home.html
@@ -322,9 +322,6 @@
         <input type="range" min="0" max="2" value="0" id="lunch_range" onchange="update_lunch()" class="unselectable">
         <p id="lunch_label" class="unselectable">ABC</p>
       </div>
-      <div style="margin-left: auto; align-self: center;">
-        <a href="https://drive.google.com/file/d/12Xbk-tNsQvIsS5_Ty4eVJPHRQAow6tjI/view" target="_blank">CRLS Bell Schedule 2021-2022</a>
-      </div>
     </div>
     <div id="scheduleTable"></div>
   </div>

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -17,7 +17,7 @@ logo = document.getElementById("logo");
 
 // Controls whether to use the covid-19 schedule or the regular schedule
 const covid_schedule = true;
-let current_schedule = covid_schedule ? "2021fa" : "regular";
+let current_schedule = covid_schedule ? "2022fa" : "regular";
 // For covid-19 schedule
 let selected_day_of_week = -1;
 let day_of_week;
@@ -193,8 +193,8 @@ function update_lunch() {
 
 // Takes an object with "room" and "id"
 function get_lunch(p3room, p3id) {
-    // RSTA auto garage is lunch A
-    if (p3room === "GAR") {
+    // RSTA auto garage and Media Arts Studio are lunch A
+    if (p3room === "GAR" || p3room === "MAS") {
         return "a";
     }
 
@@ -211,15 +211,19 @@ function get_lunch(p3room, p3id) {
         return "c";
     }
 
-    // Rindge building floors 1 and 2 are lunch A
-    if (floor <= 2) {
+    // Rindge building floors 1 (RSTA), 4, and 5 are lunch A
+    if (floor === 1 || floor >= 4) {
         return "a";
     }
-    // Rindge building floors 3, 4, 5 are lunch C if science, lunch B otherwise
-    if (p3id.startsWith("S")) {
-        return "c";
-    } else {
-        return "b";
+    
+    // Rindge building floors 2 and 3 are lunch B; if science, lunch C
+    if (floor === 2 || floor === 3) {
+        if (p3id.startsWith("S")) {
+            return "c";
+        }
+        else {
+            return "b";
+        }
     }
 }
 
@@ -270,10 +274,10 @@ function get_period_name(default_name, day_of_week) {
         const [, base, suffix] = /^(.+?)(-[abc])?$/.exec(current_schedule);
 
         // Determine which covid schedule to use
-        if (day_of_week === 3) {
-            current_schedule = `2021fa-w${suffix || ""}`;
+        if (day_of_week === 4 || day_of_week === 5) {
+            current_schedule = `2022fa-tf${suffix || ""}`;
         } else {
-            current_schedule = `2021fa${suffix || ""}`;
+            current_schedule = `2022fa${suffix || ""}`;
         }
     } else {
         bs_day = document.getElementById("schedule_title").innerHTML

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -246,7 +246,7 @@ function get_period_name(default_name, day_of_week) {
         // Guess lunch if there is a period 3 and we are not following the
         // covid schedule
         for (const { period, room, id } of period_names.black) {
-            if (period.includes("03") || period.includes("BLOCK 3")) {
+            if (period.includes("03") || period.includes("BLOCK 3") || period.includes("3") || period.includes("Block 3")) {
                 // Get base of schedule name (excluding lunch-specific suffix)
                 const [, base] = /^(.+?)(-[abc])?$/.exec(current_schedule);
 
@@ -310,8 +310,12 @@ function get_period_name(default_name, day_of_week) {
         if (period === default_name)
             return name;
         // "BLOCK 1", "BLOCK 2", etc.
-        if (period === `BLOCK ${default_name.slice(-1)}`)
+        // looks for both "BLOCK" and "Block" in regex - aspen may switch between the two uses
+        if (period === `Block ${default_name.slice(-1)}` || period === `BLOCK ${default_name.slice(-1)}` || period === `block ${default_name.slice(-1)}`)
             return name;
+        if (period.includes("Falcon") && default_name.includes("Falcon")) {
+            return name;
+        }
         // For periods 1, 2, 3, 4 stored as strings containing "01", etc.
         let match;
         if ((match = period.match(/0\d/))) {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1151,6 +1151,7 @@ function responseCallbackPartial(response) {
 function scheduleCallback(response) {
     if (!currentTableData.schedule) currentTableData.schedule = response;
 
+    // console.log(currentTableData.schedule);
     document.getElementById("scheduleTable").style.rowBackgroundColor = "black";
     //the following lines are used to set up the schedule table correctly
 
@@ -1160,6 +1161,9 @@ function scheduleCallback(response) {
             x.aspenPeriod.substring(x.aspenPeriod.indexOf("-") + 1)
         ).filter(Boolean)
     );
+    
+    // console.log(blackPeriods);
+    // console.log(silverPeriods);
 
     const colors = [1, 2, 3, 4, 5, 6, 7, 8].map(n => `var(--schedule${n})`);
 

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1151,7 +1151,6 @@ function responseCallbackPartial(response) {
 function scheduleCallback(response) {
     if (!currentTableData.schedule) currentTableData.schedule = response;
 
-    // console.log(currentTableData.schedule);
     document.getElementById("scheduleTable").style.rowBackgroundColor = "black";
     //the following lines are used to set up the schedule table correctly
 
@@ -1162,8 +1161,6 @@ function scheduleCallback(response) {
         ).filter(Boolean)
     );
     
-    // console.log(blackPeriods);
-    // console.log(silverPeriods);
 
     const colors = [1, 2, 3, 4, 5, 6, 7, 8].map(n => `var(--schedule${n})`);
 

--- a/public/schedule.toml
+++ b/public/schedule.toml
@@ -929,4 +929,347 @@ end = 15:00:00.001
 
 # }}}
 
+
+
+# Fall 2022 schedule, SY22-23 {{{
+# In effect since September 10, 2021
+
+# Monday-Wednesday schedule, lunch-agnostic {{{
+[[2022fa]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2022fa]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2022fa]]
+name = "Lunch A"
+start = 11:30:00.000
+end = 12:00:00.000
+
+[[2022fa]]
+name = "Lunch B"
+start = 12:17:00.000
+end = 12:47:00.000
+
+[[2022fa]]
+name = "Lunch C"
+start = 13:00:00.000
+end = 13:30:00.000
+
+[[2022fa]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2022fa]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Monday-Wednesday Schedule, Lunch A {{{
+[[2022fa-a]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-a]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2022fa-a]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2022fa-a]]
+name = "Lunch"
+start = 11:30:00.000
+end = 12:00:00.000
+
+[[2022fa-a]]
+name = "Period 3"
+start = 12:05:00.000
+end = 13:30:00.000
+
+[[2022fa-a]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2022fa-a]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Non-Wednesday schedule, Lunch B {{{
+[[2022fa-b]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-b]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2022fa-b]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2022fa-b]]
+name = "Period 3"
+start = 11:32:00.000
+end = 12:17:00.000
+
+[[2022fa-b]]
+name = "Lunch"
+start = 12:17:00.000
+end = 12:47:00.000
+
+[[2022fa-b]]
+name = "Period 3"
+start = 12:50:00.000
+end = 13:30:00.000
+
+[[2022fa-b]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2022fa-b]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Non-Wednesday schedule, Lunch C {{{
+[[2022fa-c]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-c]]
+name = "Period 1"
+start = 08:35:00.000
+end = 10:00:00.000
+
+[[2022fa-c]]
+name = "Period 2"
+start = 10:05:00.000
+end = 11:30:00.000
+
+[[2022fa-c]]
+name = "Period 3"
+start = 11:35:00.000
+end = 13:00:00.000
+
+[[2022fa-c]]
+name = "Lunch"
+start = 13:00:00.000
+end = 13:30:00.000
+
+[[2022fa-c]]
+name = "Period 4"
+start = 13:35:00.000
+end = 15:00:00.000
+
+[[2022fa-c]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Thursday/Friday schedule, lunch-agnostic {{{
+[[2022fa-tf]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-tf]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2022fa-tf]]
+name = "Falcon Block"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2022fa-tf]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2022fa-tf]]
+name = "Lunch A"
+start = 11:50:00.000
+end = 12:20:00.000
+
+[[2022fa-tf]]
+name = "Lunch B"
+start = 12:32:00.000
+end = 13:02:00.000
+
+[[2022fa-tf]]
+name = "Lunch C"
+start = 13:10:00.000
+end = 13:40:00.000
+
+[[2022fa-tf]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2022fa-tf]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, Lunch A {{{
+[[2022fa-tf-a]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-tf-a]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2022fa-tf-a]]
+name = "Falcon Block"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2022fa-tf-a]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2022fa-tf-a]]
+name = "Lunch"
+start = 11:50:00.000
+end = 12:20:00.000
+
+[[2022fa-tf-a]]
+name = "Period 3"
+start = 12:25:00.000
+end = 13:40:00.000
+
+[[2022fa-tf-a]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2022fa-tf-a]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Thursday/Friday schedule, Lunch B {{{
+[[2022fa-tf-b]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-tf-b]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2022fa-tf-b]]
+name = "Falcon Block"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2022fa-tf-b]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2022fa-tf-b]]
+name = "Period 3"
+start = 11:52:00.000
+end = 12:32:00.000
+
+[[2022fa-tf-b]]
+name = "Lunch"
+start = 12:32:00.000
+end = 13:02:00.000
+
+[[2022fa-tf-b]]
+name = "Period 3"
+start = 13:05:00.000
+end = 13:40:00.000
+
+[[2022fa-tf-b]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2022fa-tf-b]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+# Wednesday schedule, Lunch C {{{
+[[2022fa-tf-c]]
+name = "Before School"
+start = 07:00:00.000
+end = 08:25:00.000
+
+[[2022fa-tf-c]]
+name = "Period 1"
+start = 08:35:00.000
+end = 09:50:00.000
+
+[[2022fa-tf-c]]
+name = "Falcon Block"
+start = 09:55:00.000
+end = 10:30:00.000
+
+[[2022fa-tf-c]]
+name = "Period 2"
+start = 10:35:00.000
+end = 11:50:00.000
+
+[[2022fa-tf-c]]
+name = "Period 3"
+start = 11:55:00.000
+end = 13:10:00.000
+
+[[2022fa-tf-c]]
+name = "Lunch"
+start = 13:10:00.000
+end = 13:40:00.000
+
+[[2022fa-tf-c]]
+name = "Period 4"
+start = 13:45:00.000
+end = 15:00:00.000
+
+[[2022fa-tf-c]]
+name = "After School"
+start = 15:00:00.000
+end = 15:00:00.001
+# }}}
+
+
+
 # vim: set fdm=marker:

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -67,7 +67,7 @@ export async function get_student(
       // exclude classes that don't recieve grades in Aspen
       if ([
         "Study Support", "Advisory", "Community Meeting", "PE Athletics",
-        "PE 10-12 Wellness Elective", "PE RSTA",
+        "PE 10-12 Wellness Elective", "PE RSTA", "Falcon Block Balance", "Falcon Pathway", 
       ].includes(details.name)) {
         return undefined;
       }

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -210,7 +210,6 @@ export async function get_schedule(
         }
       }).filter(isScheduleItem)
     );
-    // console.log( { black, silver});
     return { black, silver };
   });
 }

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -67,7 +67,7 @@ export async function get_student(
       // exclude classes that don't recieve grades in Aspen
       if ([
         "Study Support", "Advisory", "Community Meeting", "PE Athletics",
-        "PE 10-12 Wellness Elective",
+        "PE 10-12 Wellness Elective", "PE RSTA",
       ].includes(details.name)) {
         return undefined;
       }

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -114,6 +114,13 @@ export async function get_schedule(
 ): Promise<Schedule> {
   return await get_session(username, password, async session => {
     const current_quarter = await get_current_quarter(session, Year.Current);
+    let current_semester;
+    if (current_quarter <= 2) {
+        current_semester = 1;
+    }
+    else {
+      current_semester = 2;
+    }
     const initial_page = await (await fetch(
       "https://aspen.cpsd.us/aspen/studentScheduleContextList.do?navkey=myInfo.sch.list", {
         headers: {
@@ -123,8 +130,9 @@ export async function get_schedule(
     )).text();
     // This is a term OID that is specific to the schedule view (not the same
     // as the OIDs in the output of get_quarter_oids)
+    // currently uses semester view to scrape, quarter view behaved weirdly, can switch back easily though
     const [, term_oid] = new RegExp(
-      String.raw`<option value="(.+)">Q${current_quarter}</option>`
+      String.raw`<option value="(.+)">S${current_semester}</option>`
     ).exec(initial_page) as RegExpExecArray;
 
     const schedule_page = await (await fetch(
@@ -147,14 +155,15 @@ export async function get_schedule(
 
     // Get a matrix of the cells in the first three columns of the table, then
     // transpose it to get a list of periods, a list of silver day classes
-    // (from Monday), and a list of black day classes (from Tuesday).
+    // (from Thursday), and a list of black day classes (from Friday).
 
     const transpose = <T>(matrix: T[][]): T[][] =>
       matrix[0].map((col, i) => matrix.map(row => row[i]));
     // Transpose algorithm: https://stackoverflow.com/a/46805290
 
+    // row => [1, 5, 6] will get the periods from column 1 and all the class names from Thursday (row 5) and Friday (row 6)
     const [periods, silver_html, black_html] = transpose([...rows].map(row =>
-      [1, 2, 3].map(n =>
+      [1, 5, 6].map(n =>
         row.querySelector(`td:nth-child(${n})`)
           ?.querySelector("td, th")?.innerHTML.trim() ?? ""
       )
@@ -201,7 +210,7 @@ export async function get_schedule(
         }
       }).filter(isScheduleItem)
     );
-
+    // console.log( { black, silver});
     return { black, silver };
   });
 }


### PR DESCRIPTION
- Changes the schedule to the new weekly schedule in use this year (including Falcon Blocks)
- Updated the lunch detection to match the new schedule
- Changed schedule scraping to use semester view instead of quarter view because of Aspen changes
- Changed schedule scraping to use Thursday and Friday for Silver and Black classes instead of Monday and Tuesday
- Updated Regex expressions to catch different capitalizations of "Block" when referring to periods of the schedule (Block 1, Block 2, etc...)
- excludes Falcon Blocks from the grades tab