### PR TITLE
Added script to run the webapp as a service

### DIFF
--- a/aspine.service
+++ b/aspine.service
@@ -1,0 +1,16 @@
+[Unit]
+Description= Systemctl Service for Aspine
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory= /var/www/aspine/
+ExecStart= sudo NODE_ENV=production npm start
+Restart=always
+RestartSec=10
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=aspine
+
+[Install]
+WantedBy=multi-user.target

--- a/enable-service.sh
+++ b/enable-service.sh
@@ -1,0 +1,4 @@
+sudo mv aspine.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable aspine.service
+sudo systemctl start aspine.service


### PR DESCRIPTION
added enable-service.sh which can be run once as a post installation script to make the web application persistant across updates and reboots